### PR TITLE
[WIP] Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ $metabox->build();
 
 ##### dependency 
 (array) (Optional) Metabox dependency based on metafield conditions. Conditionals include `>, <, >=, <=, ==, !=, between, outside`. For `>, <, >=, <=`, only accept numeric values. For `==, !=`, can accept single value or array of values to match. e.g. `value` or `[3, "343", 55, "Value"]`. For `between & outside` only accepts array of values. e.g. `[2, 6]`. 
+```
+'dependency' => [
+    'key'       => 'metakey',
+    'value'     => 'value', // Format: 'value' || '[value, value, ...]'
+    'condition' => '>, <, >=, <=, ==, !=, between, outside',
+]
+```
 
 ##### remove
 (string|array) (Optional) Remove support for a feature from a post type. `custom-fields` is set as default.
@@ -121,14 +128,6 @@ $metabox->build();
 - 'revisions' (will store revisions)
 - 'page-attributes' (template and menu order) (hierarchical must be true)
 - 'post-formats' removes post formats, 
-
-```
-'dependency' => [
-    'key'       => 'metakey',
-    'value'     => 'value', // Format: 'value' || '[value, value, ...]'
-    'condition' => '>, <, >=, <=, ==, !=, between, outside',
-]
-```
 
 
 ## Fields
@@ -372,14 +371,14 @@ For validation, use `pattern` attribute with `tel` input if browser doesn't supp
 Can be inserted between metakeys to create titles, breaks, messages or additional instructions. 
 
 
-##### Nested
+##### Object
 ```
 'metakey' => [
     'label'       => '',
     'description' => '',
     'dependency'  => [],
     'callback'    => '',
-    'repeater'    => bool
+    'repeater'    => true|false
     'subfields'   => [
         'subkey' => [
             'type'   => 'text', 
@@ -396,7 +395,7 @@ Can be inserted between metakeys to create titles, breaks, messages or additiona
     ],
 ],
 ```
-Builds a nested json object into the `metakey`, this can be a repeater with an array of objects stored if `repeater` set to true. Note: Editor field currently doesn't work with repeater field. Also subkeys do not except `dependency` or `callback` attributes.
+Builds a json object into the `metakey`, this can be a repeater with an array of objects stored if `repeater` set to true. Note: Editor field currently doesn't work with repeater field. Also subkeys do not except `dependency` or `callback` attributes.
 
 ### Field Properties Information
 
@@ -443,10 +442,10 @@ Builds a nested json object into the `metakey`, this can be a repeater with an a
 (string) (Optional) Give the field a little more style love. Work with all fields except, select2s, checkbox, and radio field types. 
 
 ##### subfields 
-(array) (Optional) Nested children fields. This gets saved as an array. NOTE: `Dependency & Callbacks` attributes don't work with subfield attributes.
+(array) (Optional) Object children fields. This gets saved as an array. NOTE: `Dependency & Callbacks` attributes don't work with subfield attributes.
 
 ##### repeater 
-(bool) (Optional) Whether or not nested children subfields are repeated. NOTE: `Editor` fields currently do not work in repeaters.
+(bool) (Optional) Whether or not object children subfields are repeated. This creates an array of objects. NOTE: `Editor` fields currently do not work in repeaters.
 
 ```
 'dependency' => [

--- a/README.md
+++ b/README.md
@@ -40,31 +40,33 @@ Used to build simple custom metabox.
 use WordPressMeta\Metabox;
 
 $metabox = new Metabox();
-$metabox->setSettings(array(
+$metabox->settings = [
    ... Settings
-));
-$metabox->setFields(array(
+];
+$metabox->fields = [
     ... Fields
-));
+];
 $metabox->build();
 ```
 
 ## Settings
 ```
-array(
+[
     'title'        => '',
     'id'           => '',
     'instructions' => '',
-    'post_type'    => array() || '',
-    'post'         => array() || '',
-    'parent'       => array() || '',
-    'template'     => array() || '',
-    'taxonomy'     => array(),
+    'prefix'       => '',
+    'post_type'    => [] || '',
+    'post'         => [] || '',
+    'parent'       => [] || '',
+    'template'     => [] || '',
+    'taxonomy'     => [],
     'operator'     => '',
     'location'     => 'normal',
     'priority'     => 'high',
-    'dependency'   => array()
-)
+    'dependency'   => [],
+    'remove'       => ['custom-fields']
+]
 ```
 
 ##### title
@@ -76,6 +78,9 @@ array(
 ##### instructions
 (string) (Optional) Can contain html tags.
 
+##### prefix
+(string) (Optional) Adds to the field names below. So prefix = `something` will append `something_fieldname`. If you add the `something_` it will still be `something_fieldname`.
+
 ##### location
 (string) (Optional) The context within the screen where the boxes should display. Available contexts vary from screen to screen. Post edit screen contexts include 'normal', 'side', and 'advanced'. Comments screen contexts include 'normal' and 'side'. Default `normal`.
 
@@ -86,16 +91,16 @@ array(
 (string|array) (Optional) The post type which to show the box. Accepts a single post type or an array of post types. Default `all post` types.
 
 ##### post
-(string|array) (Optional) Metabox will only display on specific posts entered into array. e.g. `array('242', '234', '12')` or `'12'`
+(string|array) (Optional) Metabox will only display on specific posts entered into array. e.g. `['242', '234', '12']` or `'12'`
 
 ##### parent
-(string|array) (Optional) Metabox will only display on children posts of specific parent post(s) entered into array. e.g. `array('242')` or `'242'`
+(string|array) (Optional) Metabox will only display on children posts of specific parent post(s) entered into array. e.g. `['242']` or `'242'`
 
 ##### taxonomy
-(array) (Optional) Metabox will only display on terms that are specified in taxonomies. e.g. `array('category' => 'rankings')` or `array('category' => 'rankings', 'post_tag' => 'schools')` or `array('category' => array('rankings', 'schools'), 'post_tag' => 'schools')`
+(array) (Optional) Metabox will only display on terms that are specified in taxonomies. e.g. `['category' => 'rankings']` or `['category' => 'rankings', 'post_tag' => 'schools']` or `['category' => ['rankings', 'schools'], 'post_tag' => 'schools']`
 
 ##### template
-(string|array) (Optional) Metabox will only display on specified template. e.g. `array('front-page.php', 'contact-page.php')` or `'front-page.php'`
+(string|array) (Optional) Metabox will only display on specified template. e.g. `['front-page.php', 'contact-page.php']` or `'front-page.php'`
 
 ##### operator
 (string) (Optional) How you'd like to query your location rules together, `post_type`, `post`, `parent`, `taxonomy`. Accepts `AND` or `OR`. Default is set to 'OR'.
@@ -103,39 +108,52 @@ array(
 ##### dependency 
 (array) (Optional) Metabox dependency based on metafield conditions. Conditionals include `>, <, >=, <=, ==, !=, between, outside`. For `>, <, >=, <=`, only accept numeric values. For `==, !=`, can accept single value or array of values to match. e.g. `value` or `[3, "343", 55, "Value"]`. For `between & outside` only accepts array of values. e.g. `[2, 6]`. 
 
+##### remove
+(string|array) (Optional) Remove support for a feature from a post type. `custom-fields` is set as default.
+- 'title'
+- 'editor' (content)
+- 'author'
+- 'thumbnail' (featured image) (current theme must also support Post Thumbnails)
+- 'excerpt'
+- 'trackbacks'
+- 'custom-fields'
+- 'comments' (also will see comment count balloon on edit screen)
+- 'revisions' (will store revisions)
+- 'page-attributes' (template and menu order) (hierarchical must be true)
+- 'post-formats' removes post formats, 
+
 ```
-'dependency' => array(
+'dependency' => [
     'key'       => 'metakey',
     'value'     => 'value', // Format: 'value' || '[value, value, ...]'
     'condition' => '>, <, >=, <=, ==, !=, between, outside',
-)
+]
 ```
-
 
 
 ## Fields
 ```
-$metabox->setFields(array(
+$metabox->fields = [
     ...
-));
+];
 ```
 
 ##### Checkbox
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'checkbox',
     'label'       => '', 
     'description' => '', 
-    'dependency'  => array(),
+    'dependency'  => [],
     'callback'    => '',
-),
+],
 ```
 Checkboxes, values are always `0` & `1`. e.g. If checked `metakey` will have meta value of `1` otherwise it'll be `0`. 
 
 
 ##### Date
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'date', 
     'value'       => '', // Format: YYYY-MM-DD
     'label'       => '', 
@@ -143,29 +161,29 @@ Checkboxes, values are always `0` & `1`. e.g. If checked `metakey` will have met
     'required'    => false,
     'readonly'    => false,
     'pattern'     => '',
-    'dependency'  => array(),
+    'dependency'  => [],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Editor
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'editor', 
     'value'       => '',
     'label'       => '', 
     'description' => '', 
-    'dependency'  => array(),
+    'dependency'  => [],
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Email
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'email', 
     'value'       => '',
     'label'       => '', 
@@ -175,16 +193,16 @@ Checkboxes, values are always `0` & `1`. e.g. If checked `metakey` will have met
     'readonly'    => false,
     'pattern'     => '',
     'maxlength'   => '',
-    'dependency'  => array(),
+    'dependency'  => [],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Number
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'number', 
     'value'       => '',
     'label'       => '', 
@@ -196,87 +214,87 @@ Checkboxes, values are always `0` & `1`. e.g. If checked `metakey` will have met
     'min'         => '',
     'max'         => '',
     'maxlength'   => '',
-    'dependency'  => array(),
+    'dependency'  => [],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Radio
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'radio', 
     'label'       => '', 
     'description' => '', 
-    'dependency'  => array(),
-    'options'     => array('Category 1' => 'value', 'Category 1' => 'value', ...),
+    'dependency'  => [],
+    'options'     => ['Category 1' => 'value', 'Category 1' => 'value', ...],
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Select
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'select-multiple', 
     'label'       => '', 
     'description' => '', 
     'required'    => false, 
-    'dependency'  => array(),
-    'options'     => array('Label' => 'value', 'Label' => 'value', ...),
+    'dependency'  => [],
+    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Select Multiple
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'select-multiple', 
     'label'       => '', 
     'description' => '', 
     'required'    => false, 
-    'dependency'  => array(),
-    'options'     => array('Label' => 'value', 'Label' => 'value', ...),
+    'dependency'  => [],
+    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Select2
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'select2', 
     'label'       => '', 
     'description' => '', 
     'required'    => false, 
-    'dependency'  => array(),
-    'options'     => array('Label' => 'value', 'Label' => 'value', ...),
+    'dependency'  => [],
+    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Select2 Multiple
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'select2-multiple', 
     'label'       => '', 
     'description' => '', 
     'required'    => false, 
-    'dependency'  => array(),
-    'options'     => array('Label' => 'value', 'Label' => 'value', ...),
+    'dependency'  => [],
+    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Tel
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'tel', 
     'value'       => '',
     'label'       => '', 
@@ -286,17 +304,17 @@ Checkboxes, values are always `0` & `1`. e.g. If checked `metakey` will have met
     'readonly'    => false,
     'pattern'     => '', 
     'maxlength'   => '',
-    'dependency'  => array(),
+    'dependency'  => [],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 For validation, use `pattern` attribute with `tel` input if browser doesn't support HTML5 `tel` validation.
 
 
 ##### Text
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'text', 
     'value'       => '',
     'label'       => '', 
@@ -306,32 +324,32 @@ For validation, use `pattern` attribute with `tel` input if browser doesn't supp
     'readonly'    => false,
     'pattern'     => '',
     'maxlength'   => '',
-    'dependency'  => array(),
+    'dependency'  => [],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 
 ##### Textarea
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'textarea', 
     'value'       => '',
     'label'       => '', 
     'description' => '', 
     'required'    => false,
     'readonly'    => false,
-    'dependency'  => array(),
+    'dependency'  => [],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 
 ##### URL
 ```
-'metakey' => array(
+'metakey' => [
     'type'        => 'url', 
     'value'       => '',
     'label'       => '', 
@@ -341,10 +359,10 @@ For validation, use `pattern` attribute with `tel` input if browser doesn't supp
     'readonly'    => false,
     'pattern'     => '',
     'maxlength'   => '',
-    'dependency'  => array(),
+    'dependency'  => [],
     'style'       => '',
     'callback'    => '',
-),
+],
 ```
 
 ##### Snippet
@@ -356,27 +374,27 @@ Can be inserted between metakeys to create titles, breaks, messages or additiona
 
 ##### Nested
 ```
-'metakey' => array(
+'metakey' => [
     'label'       => '',
     'description' => '',
-    'dependency'  => array(),
+    'dependency'  => [],
     'callback'    => '',
     'repeater'    => bool
-    'subfields'   => array(
-        'subkey' => array(
+    'subfields'   => [
+        'subkey' => [
             'type'   => 'text', 
             'value'  => '',
             'label'  => '',
             ...
-        ),
-        'subkey' => array(
+        ],
+        'subkey' => [
             'type'   => 'text', 
             'value'  => '',
             'label'  => '',
             ...
-        )
-    )
-)
+        ],
+    ],
+],
 ```
 Builds a nested json object into the `metakey`, this can be a repeater with an array of objects stored if `repeater` set to true. Note: Editor field currently doesn't work with repeater field. Also subkeys do not except `dependency` or `callback` attributes.
 
@@ -398,7 +416,7 @@ Builds a nested json object into the `metakey`, this can be a repeater with an a
 (string) (Optional) Can contain html tags.
 
 ##### options 
-(array) (Optional) e.g. `'options'  => array('Category 1' => 'value', 'Category 1' => 'value', ...)`
+(array) (Optional) e.g. `'options'  => ['Category 1' => 'value', 'Category 1' => 'value', ...]`
 
 ##### pattern 
 (string) (Optional) The pattern attribute specifies a regular expression that the <input> element's value is checked against. Note: The pattern attribute works with the following input types: text, date, search, url, number, tel, and email. e.g. `[A-Za-z]{3}`
@@ -431,136 +449,66 @@ Builds a nested json object into the `metakey`, this can be a repeater with an a
 (bool) (Optional) Whether or not nested children subfields are repeated. NOTE: `Editor` fields currently do not work in repeaters.
 
 ```
-'dependency' => array(
+'dependency' => [
     'key'       => 'metakey',
     'value'     => 'value', // Format: 'value' || '[value, value, ...]'
     'condition' => '>, <, >=, <=, ==, !=, between, outside',
-)
+],
 ```
 
 
 ## Example Usage:
 ```
 $widgetXYZ = new Metabox();
-$widgetXYZ->setSettings(array(
+$widgetXYZ->settings = [
    'title'        => 'Title',
    'instructions' => '',
-   'post_type'    => array('post', 'pages'),
+   'post_type'    => ['post', 'pages'],
    'location'     => 'side',
    'priority'     => 'high',
-));
-$widgetXYZ->setFields(array(
-    'title' => array(
+];
+$widgetXYZ->fields = [
+    'title' => [
         'value'       => 'Default Title Name',
         'type'        => 'text',
         'description' => '',
         'label'       => 'Title',
         'placeholder' => 'Title',
-    ),
-    'cta' => array(
+    ],
+    'cta' => [
         'type'  => 'text',
         'label' => 'Title',
         'placeholder' => 'tittle',
         'pattern' => '[A-Za-z]{3}',
         'required' => true,
-        'dependency' => array(
+        'dependency' => [
             'key'       => 'title',
             'value'     => 'value',
             'condition' => '==',
-        )
-    ),
-    'degree_level_id' => array(
+        ]
+    ],
+    'degree_level_id' => [
         'type'  => 'select',
         'label' => 'Degree Level',
         'options'  => $arrayMap,
-    ),
-    'category_id' => array(
+    ],
+    'category_id' => [
         'type'  => 'select',
         'label' => 'Category',
-        'options'  => array('Category 1' => 'value', 'Category 1' => 'value', ...),  
-    ),
-    'subject_id' => array(
+        'options'  => ['Category 1' => 'value', 'Category 1' => 'value', ...],  
+    ],
+    'subject_id' => [
         'type'  => 'text',
         'label' => 'Degree Level',
-        'options'  => array('Category 1' => 'value', 'Category 1' => 'value', ...),   
-        'dependency' => array(
+        'options'  => ['Category 1' => 'value', 'Category 1' => 'value', ...],   
+        'dependency' => [
             'key'       => 'category_id',
             'value'     => '[1, 6]',
             'condition' => '==',
-        )
-    ),
-));
+        ]
+    ],
+];
 $widgetXYZ->build();
-```
-
-
-#### Example Usage: Using Class Shorthand Arguments
-```
-new Metabox(array(
-    'settings' => array(
-        'title'    => 'Custom Meta Goodies',
-        'post_type' => array('post', 'page'), 
-        'location' => 'normal',
-        'priority' => 'high',
-    ),
-    'fields'  => array(
-        'test_title' => array(
-            'type'  => 'text',
-            'label' => 'Text Type',
-            'description' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.',
-            'placeholder' => 'Enter It Here',
-        ),
-        'tessst' => array(
-            'type'  => 'textarea',
-            'label' => 'Textarea',
-            'placeholder' => 'cta'
-        ),
-        'category_id' => array(
-            'type'  => 'select',
-            'label' => 'Select Options',
-            'options'  => array('Category 1' => 'value', 'Category 1' => 'value', ...),  
-        ),
-        'cheeee' => array(
-            'type'  => 'select_multiple',
-            'label' => 'Select - Multiple',
-            'options'  => array('Category 1' => 'value', 'Category 1' => 'value', ...),  
-            'dependency' => array(
-                'key'       => 'category_id',
-                'value'     => '[1, 6]',
-                'condition' => '==',
-            )
-        ),
-        '<span class="label">Checkbox Inputs</span>',
-        'test_checkbox' => array(
-            'type'  => 'checkbox',
-            'label' => 'Do you like mess?',
-        ),
-        'test_checkbox_2' => array(
-            'type'  => 'checkbox',
-            'label' => 'Do you like him?',
-            'dependency' => array(
-                'key'       => 'test_checkbox',
-                'value'     => 1,
-                'condition' => '==',
-            )
-        ),
-        'test_radio' => array(
-            'type'  => 'radio',
-            'label' => 'Radio Inputs',
-            'options'  => array('Category 1' => 'value', 'Category 1' => 'value', ...),  
-        ),
-        'test_favorite' => array(
-            'type'  => 'datalist',
-            'label' => 'Datalist Input',
-            'options'  => array('Category 1' => 'value', 'Category 1' => 'value', ...),  
-        ),
-        'edissstor' => array(
-            'type'  => 'editor',
-            'label' => 'Editor Type',
-            'description' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Totam corporis alias, aperiam soluta cumque ipsum accusamus nihil libero aliquam, fugiat?',
-        ),
-    )
-));
 ```
 
 # Meta Class
@@ -571,22 +519,22 @@ Used to retrieve meta fields with defined search query/fields. **Requirements to
 use WordPressMeta\Meta;
 
 $meta = new Meta;
-$meta->setMeta(array(
+$meta->setMeta([
     ... Meta
 ));
-$meta->setQuery(array(
+$meta->setQuery([
     ... Query
 ));
 $meta->init();
 ```
 ## Meta
 ```
-array(
+[
     'metakey',
     'metakey' => '3',
-    'metakey' => array('searchValue', 'replaceableValue'),
-    'metakey' => array('2', '5'),
-    'metakey' => array('1', '5'),
+    'metakey' => ['searchValue', 'replaceableValue'],
+    'metakey' => ['2', '5'],
+    'metakey' => ['1', '5'],
     'metakey'
 )
 ```
@@ -596,36 +544,36 @@ Pulls in posts with attached `metakey`, no matter the value. Basically equals th
 #### Key with Value: `'metakey' => 'value'` 
 Pulls in posts where `metakey` equals `value`. You may also look for metakeys that exists but have no value. `'metakey' => ''`
 
-#### Key with Array Value: `'metakey' => array('searchValue', 'replaceableValue')` 
+#### Key with Array Value: `'metakey' => ['searchValue', 'replaceableValue')` 
 Pulls in posts like above using the `searchValue`. This allows you to replace `metakey` values from the dashboard.
 
 
 ## Query
 ```
-array(
-    'post'      => array(),
-    'post_type' => array(),
-    'parent'    => array(),
-    'taxonomy'  => array('taxonomy' => array('term', 'term')),
-    'template'  => array(),
+[
+    'post'      => [],
+    'post_type' => [],
+    'parent'    => [],
+    'taxonomy'  => ['taxonomy' => ['term', 'term')],
+    'template'  => [],
     'slug'      => '',
     'wp_args'   => Refer to: https://codex.wordpress.org/Class_Reference/WP_Query,
 )
 ```
 ##### post
-(string|array) (Optional) Specific posts entered into array. e.g. `array('242', '234', '12')`
+(string|array) (Optional) Specific posts entered into array. e.g. `['242', '234', '12']`
 
 ##### post_type
 (string|array) (Optional) Accepts a single post type or an array of post types. Default is all post types.
 
 ##### parent
-(string|array) (Optional) Only children posts of specific parent post(s) entered into array. e.g. `array('242')`
+(string|array) (Optional) Only children posts of specific parent post(s) entered into array. e.g. `['242')`
 
 ##### taxonomy
-(array) (Optional) Only terms that are specified in taxonomies. e.g. `array('category' => 'rankings')` or `array('category' => 'rankings', 'post_tag' => 'schools')` or `array('category' => array('rankings', 'schools'), 'post_tag' => 'schools')`
+(array) (Optional) Only terms that are specified in taxonomies. e.g. `['category' => 'rankings']` or `['category' => 'rankings', 'post_tag' => 'schools']` or `['category' => ['rankings', 'schools'], 'post_tag' => 'schools']`
 
 ##### template
-(string|array) (Optional) Only terms that are specified in template. e.g. `array('front-page.php', 'contact-page.php')`
+(string|array) (Optional) Only terms that are specified in template. e.g. `['front-page.php', 'contact-page.php']`
 
 ##### slug
 (string) (Optional) Only page specified by slug. e.g. `'page-slug-name'`
@@ -637,38 +585,18 @@ array(
 #### Example Usage
 ```
 $meta = new Meta;
-$meta->setMeta(array(
+$meta->setMeta([
     'degree_level_id' => 2,
-    'editorial_only_page' => array(0, 2)
+    'editorial_only_page' => [0, 2)
 ));
-$meta->setQuery(array(
-    'post'      => array('5474', '6505', '6504', '6503', '234234322'),
-    'post_type' => array('post'),
-    'parent'    => array('172'),
-    'taxonomy'  => array('category' => array('college-rankings')),
-    'template'  => array('page-banner.php'),
+$meta->setQuery([
+    'post'      => ['5474', '6505', '6504', '6503', '234234322'],
+    'post_type' => ['post'],
+    'parent'    => ['172'],
+    'taxonomy'  => ['category' => ['college-rankings')],
+    'template'  => ['page-banner.php'],
     'slug'      => 'page-slug-name',
-    'wp_args'   => array( 'category__in' => array( 5, 6 ) ),
+    'wp_args'   => [ 'category__in' => [ 5, 6 ) ],
 ));
 $meta->init();
-```
-
-
-#### Example Usage: Using Class Shorthand Arguments
-```
-new Meta(array(
-    'query' => array(
-        'post'      => array('5474', '6505', '6504', '6503', '234234322'),
-        'post_type' => array('post'),
-        'parent'    => array('172'),
-        'taxonomy'  => array('category' => array('college-rankings')),
-        'template'  => array('page-banner.php'),
-        'slug'      => 'page-slug-name',
-        'wp_args'   => array( 'category__in' => array( 5, 6 ) ),
-    ),
-    'meta' => array(
-        'degree_level_id' => '1', 
-        'editorial_only_page'
-    )
-));
 ```

--- a/README.md
+++ b/README.md
@@ -519,13 +519,13 @@ Used to retrieve meta fields with defined search query/fields. **Requirements to
 use WordPressMeta\Meta;
 
 $meta = new Meta;
-$meta->setMeta([
-    ... Meta
-));
-$meta->setQuery([
-    ... Query
-));
-$meta->init();
+$meta->meta = [
+    ...Meta
+];
+$meta->query = [
+    ...Query
+];
+$meta->build();
 ```
 ## Meta
 ```
@@ -554,7 +554,7 @@ Pulls in posts like above using the `searchValue`. This allows you to replace `m
     'post'      => [],
     'post_type' => [],
     'parent'    => [],
-    'taxonomy'  => ['taxonomy' => ['term', 'term')],
+    'taxonomy'  => ['taxonomy' => ['term', 'term']],
     'template'  => [],
     'slug'      => '',
     'wp_args'   => Refer to: https://codex.wordpress.org/Class_Reference/WP_Query,
@@ -585,18 +585,18 @@ Pulls in posts like above using the `searchValue`. This allows you to replace `m
 #### Example Usage
 ```
 $meta = new Meta;
-$meta->setMeta([
+$meta->meta = [
     'degree_level_id' => 2,
-    'editorial_only_page' => [0, 2)
-));
-$meta->setQuery([
+    'editorial_only_page' => [0, 2]
+];
+$meta->query = [
     'post'      => ['5474', '6505', '6504', '6503', '234234322'],
     'post_type' => ['post'],
     'parent'    => ['172'],
     'taxonomy'  => ['category' => ['college-rankings')],
     'template'  => ['page-banner.php'],
     'slug'      => 'page-slug-name',
-    'wp_args'   => [ 'category__in' => [ 5, 6 ) ],
-));
-$meta->init();
+    'wp_args'   => ['category__in' => [5, 6]],
+];
+$meta->build();
 ```

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Pulls in posts with attached `metakey`, no matter the value. Basically equals th
 #### Key with Value: `'metakey' => 'value'` 
 Pulls in posts where `metakey` equals `value`. You may also look for metakeys that exists but have no value. `'metakey' => ''`
 
-#### Key with Array Value: `'metakey' => ['searchValue', 'replaceableValue')` 
+#### Key with Array Value: `'metakey' => ['searchValue', 'replaceableValue']` 
 Pulls in posts like above using the `searchValue`. This allows you to replace `metakey` values from the dashboard.
 
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "lint:php": "phpcs --standard=PSR2 --extensions=php .",
+    "lint:php": "phpcs --standard=PSR2 --extensions=php reivew/.",
     "lint:js": "eslint .",
     "lint:sass": "sass-lint -vq --max-warnings=0",
     "test": "run-s -c lint:* -s"

--- a/review/Meta.php
+++ b/review/Meta.php
@@ -1,0 +1,391 @@
+<?php
+
+namespace WordPressMeta;
+
+/**
+ * Meta Class
+ *
+ */
+class Meta
+{
+
+    /**
+     * Query
+     * @var array
+     */
+    private $query = array(
+        'post'      => array(),
+        'post_type' => array(),
+        'parent'    => array(),
+        'taxonomy'  => array(),
+        'template'  => array(),
+        'slug'      => '',
+        'wp_args'   => array(),
+    );
+
+
+    /**
+     * Fields
+     * @var array
+     */
+    private $meta = array();
+
+
+    /**
+     * Posts
+     * @var array
+     */
+    private $posts = array();
+
+
+    /**
+     * Results
+     * @var array
+     */
+    private $results = array();
+
+
+    /**
+     * Construct
+     * @param  array $args
+     *
+     */
+    public function __construct($args = array())
+    {
+
+        // Check if shortcut arguments are set.
+        if (empty($args) || (empty($args['meta']) && empty($args['query']))) {
+            return;
+        }
+
+        // Set query if argument query are set in shortcut arguments.
+        if (!empty($args['query']) && is_array($args['query'])) {
+            $this->setQuery($args['query']);
+        }
+
+        // Set meta if argument meta are set in shortcut arguments.
+        if (!empty($args['meta']) && is_array($args['meta'])) {
+            $this->setMeta($args['meta']);
+        }
+
+        // Iniitate shortcut setup.
+        $this->init();
+    }
+
+
+    /**
+     * Set Query
+     * @param  array $args
+     *
+     */
+    public function setQuery($args = array())
+    {
+
+        // Check if arguments are empty.
+        if (empty($args)) {
+            return;
+        }
+
+        // Set metabox object settings.
+        $this->query = array_merge($this->query, $args);
+    }
+
+
+    /**
+     * Set Fields
+     * @param  array $args
+     *
+     */
+    public function setMeta($args = array())
+    {
+        // Check if arguments are empty.
+        if (empty($args)) {
+            return;
+        }
+
+        // $_GET - Specific Meta Field.
+        if (!empty($_GET['metakey']) && !empty($_GET['action'])) {
+            // Update
+            if ($_GET['action'] == 'update') {
+                $this->meta = array($_GET['metakey'] => array(
+                    $_GET['metavalue'],
+                    $_GET['value']
+                ));
+                return;
+            }
+
+            // Remove
+            if ($_GET['action'] == 'remove') {
+                $this->meta = array($_GET['metakey'] => $_GET['metavalue']);
+                return;
+            }
+        }
+
+        // Check if single value, convert into array.
+        if (!is_array($args)) {
+            $this->meta = array($args => '*');
+            return;
+        }
+
+        // Set if numberic, set keys & wildcard.
+        foreach ($args as $key => $value) {
+            // Set wildcard selector.
+            if (is_numeric($key) && !is_array($value)) {
+                $this->meta[$value] = '*';
+                continue;
+            }
+
+            // Build meta array.
+            $this->meta[$key] = $value;
+        }
+    }
+
+
+    /**
+     * Init
+     *
+     */
+    public function init()
+    {
+
+        // Check for needed `?meta=1` and logged in to even run.
+        if (empty($_GET['meta']) || !current_user_can('administrator')) {
+            return;
+        }
+
+        // Get result posts.
+        $this->getPosts();
+
+        // Update/Removal Database call.
+        if (!empty($_GET['id']) && !empty($_GET['action'])) {
+            $this->updateDatabase($_GET['action']);
+            return;
+        }
+
+        // Show markup.
+        $this->showMarkup();
+    }
+
+
+    /**
+     * Get posts by defined query & meta.
+     *
+     */
+    public function getPosts()
+    {
+
+        // Query results.
+        $query = new \WP_Query($this->setArguments());
+
+        // Pluck only IDs from results in array.
+        $this->posts = wp_list_pluck($query->posts, 'post_title', 'ID');
+    }
+
+
+    /**
+     * Setup Arguments.
+     *
+     */
+    private function setArguments()
+    {
+        // Argument defaults.
+        $arguments = array(
+            'post_type'      => 'any',
+            'post_status'    => 'any',
+            'orderby'        => 'title',
+            'order'          => 'ASC',
+            'posts_per_page' => -1,
+        );
+
+        // Set custom WP arguments.
+        if (!empty($this->query['wp_args']) && is_array($this->query['wp_args'])) {
+            $arguments = array_merge($arguments, $this->query['wp_args']);
+        }
+
+        // Get post by slug
+        if (!empty($this->query['slug'])) {
+            $arguments['name'] = $this->query['slug'];
+        }
+
+        // Get posts, this trumps everything else.
+        if (!empty($this->query['post'])) {
+            $arguments['post__in'] = self::helperToArray($this->query['post']);
+        }
+
+        // Get posts in certain post types.
+        if (!empty($this->query['post_type'])) {
+            $arguments['post_type'] = self::helperToArray($this->query['post_type']);
+        }
+
+        // Get children posts with parent post.
+        if (!empty($this->query['parent'])) {
+            $arguments['post_parent__in'] = self::helperToArray($this->query['parent']);
+        }
+
+        // Get post with taxonomy terms.
+        if (!empty($this->query['taxonomy'])) {
+            $taxonomyQuery = array();
+
+            foreach ($this->query['taxonomy'] as $taxomony => $terms) {
+                $termCheck       = is_array($terms) ? $terms[0] : $terms;
+                $taxonomyQuery[] = array(
+                    'taxonomy' => $taxomony,
+                    'field'    => is_numeric($termCheck) ? 'term_id' : 'slug',
+                    'terms'    => $terms,
+                );
+            }
+
+            $arguments['tax_query'] = $taxonomyQuery;
+            $arguments['tax_query']['relation'] = 'OR';
+        }
+
+        // Get post assigned to template.
+        if (!empty($this->query['template'])) {
+            $templates      = self::helperToArray($this->query['template']);
+            $templatesArray = array();
+            $templatesArray['relation'] = 'OR';
+
+            foreach ($templates as $template) {
+                $templatesArray[] = array(
+                    'key'     => '_wp_page_template',
+                    'value'   => $template,
+                    'compare' => 'LIKE',
+                );
+            }
+
+            $arguments['meta_query'][] = $templatesArray;
+        }
+
+        // Get post by meta meta speicified.
+        if (!empty($this->meta)) {
+            $metaArray['relation'] = 'OR';
+
+            // Loop defined meta meta.
+            foreach ($this->meta as $key => $value) {
+                $value     = is_array($value) ? $value[0] : $value;
+                $metaArray = array('key' => $key);
+
+                if ($value != '*') {
+                    $metaArray = array_merge($metaArray, array(
+                        'value'   => $value,
+                        'compare' => '=',
+                    ));
+                }
+
+                $arguments['meta_query'][] = $metaArray;
+            }
+
+            $arguments['meta_query']['relation'] = 'OR';
+        }
+
+        // $_GET - Specific post, if selected to remove/update.
+        if (!empty($_GET['id']) && is_numeric($_GET['id'])) {
+            $arguments['page_id'] = $_GET['id'];
+
+            unset($arguments['post__in']);
+        }
+
+        // Return arguments.
+        return $arguments;
+    }
+
+
+    /**
+     * Update Database Results, whether its removal or update of rows.
+     *
+     */
+    public function updateDatabase($action)
+    {
+        // Only specific actions allowed.
+        if ($action != 'remove' && $action != 'update') {
+            return;
+        }
+
+        // Declare $wpdb global variable.
+        global $wpdb;
+
+        // Loop defined posts.
+        foreach ($this->posts as $post => $title) {
+            // Loop defined meta meta.
+            foreach ($this->meta as $key => $value) {
+                // Get value, whether its in an update array or individual string value.
+                $metaValue = is_array($value) ? $value[0] : $value;
+                $result    = false;
+
+                // Where args.
+                $where = array(
+                    'post_id'    => $post,
+                    'meta_key'   => $key,
+                );
+
+                // If specific, update where arg.
+                if ($metaValue != '*') {
+                    $where = array_merge($where, array('meta_value' => $metaValue));
+                }
+
+                // Delete.
+                if ($action == 'remove') {
+                    $result = $wpdb->delete(
+                        $wpdb->postmeta,
+                        $where
+                    );
+                }
+
+                // Update.
+                if ($action == 'update' && is_array($value)) {
+                    $result = $wpdb->update(
+                        $wpdb->postmeta,
+                        array('meta_value' => $value[1]),
+                        $where
+                    );
+                }
+
+                // If row effected, add to results list.
+                if ($result) {
+                    $this->results[$post][$key] = $value;
+                }
+            }
+        }
+
+        // Show markup.
+        $this->showMarkup();
+    }
+
+
+    /**
+     * Show Markup
+     *
+     */
+    public function showMarkup()
+    {
+
+        // Inline styles.
+        echo file_get_contents(dirname(__FILE__). '/assets/meta-styles.css');
+
+        // Inline scripts.
+        echo '<script>';
+        echo file_get_contents(dirname(__FILE__). '/assets/meta-scripts.js');
+        echo '</script>';
+
+        // Dashboard view.
+        include dirname(__FILE__) . '/views/meta-dashboard.php';
+
+        // Halt everything else.
+        die();
+    }
+
+
+    /**
+     * Helper - Convert to Array
+     *
+     */
+    public static function helperToArray($value)
+    {
+
+        if (empty($value)) {
+            return array();
+        }
+
+        return is_array($value) ? $value : array($value);
+    }
+}

--- a/review/Metabox.php
+++ b/review/Metabox.php
@@ -1,0 +1,839 @@
+<?php
+
+namespace WordPressMeta;
+
+/**
+ * Metabox Class
+ *
+ */
+class Metabox
+{
+
+    /**
+     * Post ID
+     * @var string
+     */
+    private $postID;
+
+
+    /**
+     * A nonce name value used when validating the save request
+     * @var string
+     */
+    public $nonceName = 'custom_metabox_nonce';
+
+
+    /**
+     * A nonce action used when validating the save request
+     * @var string
+     */
+    public $nonceAction = 'customMetaboxNonceAction';
+
+
+    /**
+     * Assets already loaded.
+     * @var boolean
+     */
+    private static $assetsLoaded = false;
+
+
+    /**
+     * Settings
+     * @var array
+     */
+    public $settings = [];
+
+
+    /**
+     * Settings Defaults
+     * @var array
+     */
+    private $settingsDefaults = [
+        'title'        => 'Custom Meta',
+        'id'           => '',
+        'instructions' => '',
+        'post_type'    => [],
+        'post'         => [],
+        'parent'       => [],
+        'taxonomy'     => [],
+        'template'     => [],
+        'prefix'       => '',
+        'location'     => 'normal',
+        'priority'     => 'high',
+        'dependency'   => [],
+        'remove'       => ['custom-fields']
+    ];
+
+
+    /**
+     * Fields.
+     * @var array
+     */
+    public $fields = [];
+
+
+    /**
+     * Field Defaults.
+     * @var array
+     */
+    private $fieldDefaults = [
+        'type'        => '',
+        'value'       => '',
+        'label'       => '',
+        'description' => '',
+        'placeholder' => '',
+        'options'     => [],
+        'required'    => false,
+        'pattern'     => '',
+        'style'       => '',
+        'min'         => '',
+        'max'         => '',
+        'maxlength'   => '',
+        'readonly'    => false,
+        'dependency'  => [],
+        'repeater'    => false,
+        'subfields'   => [],
+        'callback'    => '',
+    ];
+
+
+    /**
+     * Build
+     *
+     */
+    public function build()
+    {
+        add_action(
+            'init',
+            function () {
+            // Set Post ID.
+                $this->setPostID();
+
+            // Setup Settings.
+                $this->setupSettings();
+
+            // Initiate if in adminstrator area.
+                if (!$this->validateSettings()) {
+                    return;
+                }
+
+            // Check to see if assets already loaded, only load assets once.
+                if (!self::$assetsLoaded) {
+                    self::$assetsLoaded = true;
+
+                    $this->addCDNAssets();
+                    $this->assetsHeader();
+                    $this->assetsFooter();
+                    $this->removeWPFeatures();
+                }
+
+            // Setup Fields, Create Metabox, Save Metabox.
+                $this->setupFields();
+                $this->initMetabox();
+                $this->initSavePost();
+            },
+            15
+        );
+    }
+
+
+    /**
+     * Set Post ID
+     *
+     */
+    private function setPostID()
+    {
+        if (!empty($_POST['post_ID'])) {
+            $this->postID = $_POST['post_ID'];
+        } elseif (!empty($_GET['post'])) {
+            $this->postID = $_GET['post'];
+        }
+    }
+
+
+    /**
+     * Set Settings
+     * @param  array $args
+     *
+     */
+    private function setupSettings()
+    {
+        // Set Metabox ID.
+        if (empty($this->settings['id'])) {
+            $this->settings['id'] = rand(1, 100000);
+        }
+
+        // Set Prefix.
+        if (!empty($this->settings['prefix']) && substr($this->settings['prefix'], -1) != '_') {
+            $this->settings['prefix'] .= '_';
+        }
+
+        // If Properties delcared as strings, convert to arrays.
+        foreach ($this->settings as $name => &$setting) {
+            if (!empty($this->settings[$name]) &&
+                !is_array($this->settings[$name]) &&
+                is_array($this->settingsDefaults[$name])
+            ) {
+                $setting = [$this->settings[$name]];
+            }
+
+            if ($name == 'taxonomy') {
+                foreach ($setting as $taxonomy => &$term) {
+                    if (!empty($term) && !is_array($term)) {
+                        $term = [$term];
+                    }
+                }
+            }
+        }
+
+        // Defaults Settings + User Defined Settings.
+        $this->settings = array_merge($this->settingsDefaults, $this->settings);
+    }
+
+
+    /**
+     * Setup Fields
+     * @param  array $args
+     *
+     */
+    private function setupFields()
+    {
+        // Check if arguments are empty.
+        if (empty($this->fields) || !is_array($this->fields)) {
+            return;
+        }
+
+        // Setup fields.
+        foreach ($this->fields as $name => $attributes) {
+            // Remove array item, only to re-build it below.
+            unset($this->fields[$name]);
+
+            // If Instructions/Snippet
+            if (is_int($name) && is_string($attributes)) {
+                $this->fields[]['snippet'] = $attributes;
+                continue;
+            }
+
+            // Set prefixed name.
+            $name = $this->settings['prefix'] . $name;
+
+            // Stored Value.
+            $storedValue = get_post_meta($this->postID, $name, true);
+
+            if (!empty($storedValue)) {
+                $attributes['value'] = $storedValue;
+
+                // Subfield Values.
+                if (!empty($attributes['subfields'])) {
+                    $valueArray = json_decode($storedValue);
+                    $valueArray = is_object($valueArray) ? [$valueArray] : $valueArray;
+                }
+            }
+        
+            // Prefix & Merge Attributes with defaults.
+            $this->fields[$name] = array_merge($this->fieldDefaults, $attributes);
+
+            // Subfields.
+            if (empty($attributes['subfields'])) {
+                continue;
+            }
+
+            foreach ($attributes['subfields'] as $subName => $subAttributes) {
+                // If Instructions/Snippet
+                if (is_int($subName) && is_string($subAttributes)) {
+                    $this->fields[$name]['subfields'][$subName] = ['snippet' => $subAttributes];
+                    continue;
+                }
+
+                // Prefix & Merge Attributes with defaults.
+                $this->fields[$name]['subfields'][$subName] = array_merge($this->fieldDefaults, $subAttributes);
+
+                // Add Values to subfields.
+                if (empty($valueArray)) {
+                    continue;
+                }
+
+                foreach ($valueArray as $valueName => $value) {
+                    $this->fields[$name]['subfields'][$subName]['values'][] = $value->$subName;
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Custom Meta Assets(CSS & JS)
+     *
+     */
+    private function addCDNAssets()
+    {
+        add_action(
+            'admin_enqueue_scripts',
+            function () {
+            // Remove Old ACF Versions of Select2
+                wp_deregister_script('select2');
+                wp_deregister_style('select2');
+
+            // Add styles to administrator area.
+                wp_register_style(
+                    'select2-css',
+                    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css',
+                    false,
+                    '4.0.3'
+                );
+                wp_enqueue_style('select2-css');
+
+            // Add script to administrator area.
+                wp_enqueue_script(
+                    'select2-js',
+                    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js',
+                    ['jquery', 'jquery-ui-sortable'],
+                    null,
+                    false
+                );
+            }
+        );
+    }
+
+
+    /**
+     * Header - Custom Meta Assets
+     *
+     */
+    private function assetsHeader()
+    {
+        add_action(
+            'admin_head',
+            function () {
+                echo file_get_contents(dirname(__FILE__). '/assets/metabox-styles.css');
+            }
+        );
+    }
+
+
+    /**
+     * Footer - Custom Meta Assets
+     *
+     */
+    private function assetsFooter()
+    {
+        add_action(
+            'admin_footer',
+            function () {
+                echo '<script>';
+                echo file_get_contents(dirname(__FILE__) . '/assets/metabox-scripts.js');
+                echo '</script>';
+            },
+            20
+        );
+    }
+
+
+    /**
+     * Remove the default Wordpress post custom metabox from
+     * all Posts/Pages/CPT that have a Custom Metabox added.
+     * This simplifies the user selections to only one area on
+     * admin post area.
+     *
+     * @return void
+     */
+    private function removeWPFeatures()
+    {
+        if (empty($this->settings['remove'])) {
+            return;
+        }
+
+        foreach ($this->settings['remove'] as $feature) {
+            remove_post_type_support(get_post_type($this->postID), $feature);
+        }
+
+        // Remove Spacing Issue
+        if (in_array('title', $this->settings['remove']) &&
+            in_array('editor', $this->settings['remove'])
+        ) {
+            echo '<style>#post-body-content { display:none; }</style>';
+        }
+    }
+
+
+    /**
+     * Build the HTML for the Metabox fields defined by the $fields property.
+     * Set up the nonce field, re-populate the input values and create.
+     * Include minimal CSS/JS for making the metabox UI.
+     *
+     * @return void
+     */
+    private function initMetabox()
+    {
+        add_action('add_meta_boxes', function () {
+            // Add Metabox.
+            add_meta_box(
+                'custom-metabox-' . $this->settings['id'],
+                $this->settings['title'],
+                [$this, 'showMetaboxHTML'],
+                null,
+                $this->settings['location'],
+                $this->settings['priority']
+            );
+
+            // Add dependency class to metabox container to initially hide.
+            if (!empty($this->settings['dependency'])) {
+                add_filter(
+                    'postbox_classes_' . get_post_type($this->postID) . '_custom-metabox-' . $this->settings['id'],
+                    function ($classes) {
+                        $classes[] = 'data-dependency-key';
+                        return $classes;
+                    }
+                );
+            }
+        });
+    }
+
+
+    /**
+     * Show Metabox Markup
+     *
+     */
+    public function showMetaboxHTML()
+    {
+        // Add nonce for security and authentication.
+        wp_nonce_field($this->nonceAction, $this->nonceName);
+
+        // Condition Dependency.
+        if (!empty($this->settings['dependency'])) {
+            $condition  = ' data-dependency-key="' . $this->settings['dependency']['key'] . '"';
+            $condition .= ' data-dependency-value=\'' . $this->settings['dependency']['value'] . '\'';
+            $condition .= ' data-dependency-condition="' . $this->settings['dependency']['condition'] . '"';
+
+            echo '<span data-key="custom-metabox-' . $this->settings['id'] . '" 
+                        data-type="metabox" 
+                        ' . $condition . '></span>';
+        }
+
+        // Show metabox instructions.
+        if (!empty($this->settings['instructions'])) {
+            echo '<div class="instructions">' . $this->settings['instructions'] . '</div>';
+        }
+
+        // Check if fields are empty.
+        if (empty($this->fields)) {
+            return;
+        }
+
+        $this->getFields();
+    }
+
+
+    /**
+     * Meta Field Markup
+     * @param  string $name, array $attributes, string $storedValue
+     *
+     */
+    private function getFields()
+    {
+        // Show headers and fields.
+        foreach ($this->fields as $name => $attributes) {
+            // Subfields.
+            if (!empty($attributes['subfields'])) {
+                // Condition Dependency.
+                $condition = '';
+
+                if (!empty($attributes['dependency'])) {
+                    $condition  = ' data-dependency-key="' . $attributes['dependency']['key'] . '"';
+                    $condition .= ' data-dependency-value=\'' . $attributes['dependency']['value'] . '\'';
+                    $condition .= ' data-dependency-condition="' . $attributes['dependency']['condition'] . '"';
+                }
+
+                // Field markup.
+                echo '<div class="input-group type-object" 
+                           data-key="' . $name . '" 
+                           data-type="object" 
+                           ' . $condition . '>';
+            
+                // Set label if exists.
+                if (!empty($attributes['label'])) {
+                    echo '<span class="label">' . $attributes['label'] . '</span>';
+                }
+
+                // Set description if exists.
+                if (!empty($attributes['description'])) {
+                    echo '<div class="description">' . $attributes['description'] . '</div>';
+                }
+
+                // Subfields.
+                echo '<div data-subfields-container="' . $name . '" 
+                           ' . ($attributes['repeater'] ? 'data-repeater="true"' : '') . '>';
+
+                $count = 1;
+
+                if ($attributes['repeater'] && !empty(reset($attributes['subfields'])['values'])) {
+                    $count = count(reset($attributes['subfields'])['values']);
+                }
+
+                for ($i = 0; $i < $count; $i++) {
+                    echo '<div data-subfields-parent="' . $name . '">';
+
+                    foreach ($attributes['subfields'] as $subName => $subAttributes) {
+                        // Update Subname.
+                        if ($attributes['repeater']) {
+                            $subName = $name . '[' . $i . '][' . $subName . ']';
+                        } else {
+                            $subName = $name . '[' . $subName . ']';
+                        }
+                        
+                        // Update Value.
+                        $subAttributes['value'] = '';
+
+                        if (!empty($subAttributes['values'][$i])) {
+                            $subAttributes['value'] = $subAttributes['values'][$i];
+                        }
+
+                        $this->getFieldHTML($subName, $subAttributes);
+                    }
+
+                    if ($count > 1) {
+                        echo '<button class="button-remove">&#10005;</button>';
+                    }
+
+                    echo '</div>';
+                }
+
+                // End of Input Area.
+                echo '</div>';
+
+                // If repeater.
+                if ($attributes['repeater']) {
+                    echo '<div class="button-controls">
+                            <button data-subfields-add="' . $name . '" class="button-primary">Add</button>
+                          </div>';
+                }
+
+                // End of Field Group.
+                echo '</div>';
+
+                // Jump to next field.
+                continue;
+            }
+
+            // Show Fields.
+            $this->getFieldHTML($name, $attributes);
+        }
+    }
+
+
+    /**
+     * Meta Field Markup
+     * @param  string $name, array $attributes, string $storedValue
+     *
+     */
+    private function getFieldHTML($name, $attributes)
+    {
+        // Extract field attributes.
+        extract($attributes);
+
+        // HTML/Message Snippet.
+        if (!empty($snippet)) {
+            echo '<div class="snippet">' . $snippet . '</div>';
+            return;
+        }
+
+        // Field exists.
+        if (empty($type) || !file_exists(dirname(__FILE__) . '/fields/' . $type . '.php')) {
+            echo '<div class="notification-error"><strong>Type</strong> is empty or field does not exist.</div>';
+            return;
+        }
+
+        // Multiselect, append [] to name.
+        if ($type == 'select-multiple') {
+            $name .= '[]';
+        }
+
+        // Label html.
+        $labelHTML = '';
+        if (!empty($label)) {
+            $requiredHTML = $required ? '<span class="required">*</span>' : '';
+            $labelHTML    = '<label for="' . $name . '">' . $label . $requiredHTML . '</label>';
+        }
+
+        // Description html.
+        $descriptionHTML = !empty($description) ? '<div class="description">' . $description . '</div>' : '';
+
+        // Conditional dependency.
+        $condition = '';
+
+        if (!empty($dependency)) {
+            $condition  = ' data-dependency-key="' . $dependency['key'] . '"';
+            $condition .= ' data-dependency-value=\'' . $dependency['value'] . '\'';
+            $condition .= ' data-dependency-condition="' . $dependency['condition'] . '"';
+        }
+
+        // Field group.
+        echo '<div class="input-group type-' . $type . '" 
+                   data-key="' . $name . '" 
+                   data-type="' . $type . '"
+                   ' . $condition . '>';
+
+        include dirname(__FILE__) . '/fields/' . $type . '.php';
+
+        echo '</div>';
+    }
+
+
+    /**
+     * Save Meta Field Inputs
+     *
+     */
+    private function initSavePost()
+    {
+        add_action('save_post', function () {
+            // Validation Check.
+            if (!$this->validateSaveRequest()) {
+                return;
+            }
+
+            // Loop through Meta Fields.
+            foreach ($this->fields as $name => $attributes) {
+                // Check if key exists.
+                if (!array_key_exists($name, $_POST)) {
+                    continue;
+                }
+
+                // Callback.
+                if (!$this->callback($name, $attributes)) {
+                    continue;
+                }
+
+                // Subfields.
+                if (!empty($attributes['subfields'])) {
+                    $hasValue = false;
+
+                    // If repeater check deeper array.
+                    if ($attributes['repeater']) {
+                        foreach ($_POST[$name] as &$inputGroups) {
+                            foreach ($inputGroups as $inputName => &$inputValue) {
+                                if (empty($inputValue)) {
+                                    continue;
+                                }
+
+                                if (!empty($attributes['subfields'][$inputName]) &&
+                                    $attributes['subfields'][$inputName]['type'] == 'select2-multiple'
+                                ) {
+                                    $inputValue = explode(',', $inputValue);
+                                }
+
+                                $hasValue = true;
+                            }
+                        }
+                    } else {
+                        foreach ($_POST[$name] as $inputName => &$inputValue) {
+                            if (empty($inputValue)) {
+                                continue;
+                            }
+
+                            if (!empty($attributes['subfields'][$inputName]) &&
+                                $attributes['subfields'][$inputName]['type'] == 'select2-multiple'
+                            ) {
+                                $inputValue = explode(',', $inputValue);
+                            }
+
+                            $hasValue = true;
+                        }
+                    }
+
+                    // Check if multidimensional array is empty.
+                    if (!$hasValue) {
+                        $_POST[$name] = '';
+                    }
+                }
+
+                // Delete Post Meta Fields if Empty.
+                if (empty($_POST[$name]) && $attributes['type'] != 'radio') {
+                    delete_post_meta(
+                        $this->postID,
+                        $name
+                    );
+                    continue;
+                }
+
+                // select2-multiple: Convert Value to Array.
+                if (!empty($attributes['type']) && $attributes['type'] == 'select2-multiple') {
+                    $_POST[$name] = explode(',', $_POST[$name]);
+                }
+
+                // If is value is array
+                if (is_array($_POST[$name])) {
+                    $_POST[$name] = array_map('stripslashes_deep', $_POST[$name]);
+                    $_POST[$name] = wp_slash(
+                        json_encode(
+                            $_POST[$name],
+                            JSON_PRETTY_PRINT|JSON_HEX_QUOT|JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS
+                        )
+                    );
+
+                    if (JSON_ERROR_NONE != json_last_error()) {
+                        throw new \Exception('JSON encoding failed with error:' . json_last_error_msg());
+                    }
+                }
+                
+                // Update Post Meta Fields.
+                update_post_meta(
+                    $this->postID,
+                    $name,
+                    $_POST[$name]
+                );
+            }
+        });
+    }
+
+
+    /**
+     * Run through a series of tests to confirm that the save request
+     * Is valid, including checking the nonce set up in metaboxHTML()
+     *
+     * @return bool does the save request validate?
+     */
+    private function validateSaveRequest()
+    {
+        // Check if $_POST request.
+        if (empty($_POST)) {
+            return false;
+        }
+
+        // Add nonce for security and authentication
+        if (!isset($_POST[$this->nonceName])) {
+            return false;
+        }
+
+        // Check if nonce is set & nonce is valid.
+        if (!wp_verify_nonce($_POST[$this->nonceName], $this->nonceAction)) {
+            return false;
+        }
+
+        // Check if user has permissions to save data.
+        if (!current_user_can('edit_post', $this->postID)) {
+            return false;
+        }
+
+        // Check if not an autosave.
+        if (wp_is_post_autosave($this->postID)) {
+            return false;
+        }
+
+        // Check if not a revision.
+        if (wp_is_post_revision($this->postID)) {
+            return false;
+        }
+
+        // Check if fields are empty.
+        if (empty($this->fields)) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Run through a series of tests to confirm that the metabox can be
+     * added to the current post, based off of the defined settings.
+     * Checks is Admin, Post Exists, Posts, Parent, Taxonomy,
+     * and Template to display metabox.
+     *
+     * @return bool does the save request validate?
+     */
+    private function validateSettings()
+    {
+        // Check if post is empty.
+        if (empty($this->postID)) {
+            return true;
+        }
+
+        // Check if Post(s).
+        if (!empty($this->settings['post']) &&
+            in_array($this->postID, $this->settings['post'])
+        ) {
+            return true;
+        }
+
+        // Check if Post Type.
+        if (!empty($this->settings['post_type']) &&
+            in_array(get_post_type($this->postID), $this->settings['post_type'])
+        ) {
+            return true;
+        }
+
+        // Check if Parent.
+        if (!empty($this->settings['parent']) &&
+            in_array(wp_get_post_parent_id($this->postID), $this->settings['parent'])
+        ) {
+            return true;
+        }
+
+        // Check if settings.taxonomy is set.
+        if (!empty($this->settings['taxonomy'])) {
+            // Loop taxonomies & match terms for post.
+            foreach ($this->settings['taxonomy'] as $taxonomyAllowed => $termsAllowed) {
+                // Get post terms based on taxonomy.
+                $postTerms = get_the_terms($this->postID, $taxonomyAllowed);
+
+                // Check for if post terms.
+                if (is_wp_error($postTerms) || empty($postTerms)) {
+                    continue;
+                }
+
+                // Loop through post terms in taxonomy.
+                foreach ($postTerms as $postTerm) {
+                    // Check terms compared to user inputted array of values.
+                    if (in_array($postTerm->slug, $termsAllowed) ||
+                        in_array($postTerm->term_id, $termsAllowed) ||
+                        in_array($postTerm->name, $termsAllowed)
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Check if Template.
+        if (!empty($this->settings['template']) &&
+            in_array(get_page_template_slug($this->postID), $this->settings['template'])
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Callback Method
+     *
+     */
+    private function callback($name, $attributes)
+    {
+        // Check if callback exists\Check if is callable.
+        if (empty($attributes['callback']) || !is_callable($attributes['callback'])) {
+            return true;
+        }
+
+        // Data attribute of callback.
+        $data = [
+            'postID'     => $this->postID,
+            'name'       => $name,
+            'value'      => !empty($_POST[$name]) ? $_POST[$name] : '',
+            'attributes' => $attributes
+        ];
+
+        // Callback Function, pass in value as data argument.
+        return (call_user_func($attributes['callback'], $data) === false) ? false : true;
+    }
+}
+
+
+/**
+ * Add Plugin Callback Methods.
+ *
+ */
+foreach (glob(__DIR__ . '/plugins/*.php') as $filename) {
+    require_once $filename;
+}

--- a/review/Metabox.php
+++ b/review/Metabox.php
@@ -106,18 +106,18 @@ class Metabox
         add_action(
             'init',
             function () {
-            // Set Post ID.
+                // Set Post ID.
                 $this->setPostID();
 
-            // Setup Settings.
+                // Setup Settings.
                 $this->setupSettings();
 
-            // Initiate if in adminstrator area.
+                // Initiate if in adminstrator area.
                 if (!$this->validateSettings()) {
                     return;
                 }
 
-            // Check to see if assets already loaded, only load assets once.
+                // Check to see if assets already loaded, only load assets once.
                 if (!self::$assetsLoaded) {
                     self::$assetsLoaded = true;
 
@@ -127,7 +127,7 @@ class Metabox
                     $this->removeWPFeatures();
                 }
 
-            // Setup Fields, Create Metabox, Save Metabox.
+                // Setup Fields, Create Metabox, Save Metabox.
                 $this->setupFields();
                 $this->initMetabox();
                 $this->initSavePost();
@@ -170,14 +170,14 @@ class Metabox
 
         // If Properties delcared as strings, convert to arrays.
         foreach ($this->settings as $name => &$setting) {
-            if (!empty($this->settings[$name]) &&
-                !is_array($this->settings[$name]) &&
+            if (!empty($setting) &&
+                !is_array($setting) &&
                 is_array($this->settingsDefaults[$name])
             ) {
-                $setting = [$this->settings[$name]];
+                $setting = [$setting];
             }
 
-            if ($name == 'taxonomy') {
+            if ($name == 'taxonomy' && !empty($setting)) {
                 foreach ($setting as $taxonomy => &$term) {
                     if (!empty($term) && !is_array($term)) {
                         $term = [$term];
@@ -270,11 +270,11 @@ class Metabox
         add_action(
             'admin_enqueue_scripts',
             function () {
-            // Remove Old ACF Versions of Select2
+                // Remove Old ACF Versions of Select2
                 wp_deregister_script('select2');
                 wp_deregister_style('select2');
 
-            // Add styles to administrator area.
+                // Add styles to administrator area.
                 wp_register_style(
                     'select2-css',
                     'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css',
@@ -283,7 +283,7 @@ class Metabox
                 );
                 wp_enqueue_style('select2-css');
 
-            // Add script to administrator area.
+                // Add script to administrator area.
                 wp_enqueue_script(
                     'select2-js',
                     'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js',

--- a/review/Metabox.php
+++ b/review/Metabox.php
@@ -103,37 +103,38 @@ class Metabox
      */
     public function build()
     {
-        add_action(
-            'init',
-            function () {
-                // Set Post ID.
-                $this->setPostID();
+        add_action('init', function () {
 
-                // Setup Settings.
-                $this->setupSettings();
+            // Set Post ID.
+            $this->setPostID();
 
-                // Initiate if in adminstrator area.
-                if (!$this->validateSettings()) {
-                    return;
-                }
 
-                // Check to see if assets already loaded, only load assets once.
-                if (!self::$assetsLoaded) {
-                    self::$assetsLoaded = true;
+            // Setup Settings.
+            $this->setupSettings();
 
-                    $this->addCDNAssets();
-                    $this->assetsHeader();
-                    $this->assetsFooter();
-                    $this->removeWPFeatures();
-                }
 
-                // Setup Fields, Create Metabox, Save Metabox.
-                $this->setupFields();
-                $this->initMetabox();
-                $this->initSavePost();
-            },
-            15
-        );
+            // Initiate if in adminstrator area.
+            if (!$this->validateSettings()) {
+                return;
+            }
+
+
+            // Check to see if assets already loaded, only load assets once.
+            if (!self::$assetsLoaded) {
+                self::$assetsLoaded = true;
+
+                $this->addCDNAssets();
+                $this->assetsHeader();
+                $this->assetsFooter();
+                $this->removeWPFeatures();
+            }
+
+
+            // Setup Fields, Create Metabox, Save Metabox.
+            $this->setupFields();
+            $this->initMetabox();
+            $this->initSavePost();
+        }, 15);
     }
 
 
@@ -163,21 +164,23 @@ class Metabox
             $this->settings['id'] = rand(1, 100000);
         }
 
+
         // Set Prefix.
         if (!empty($this->settings['prefix']) && substr($this->settings['prefix'], -1) != '_') {
             $this->settings['prefix'] .= '_';
         }
 
+
         // If Properties delcared as strings, convert to arrays.
         foreach ($this->settings as $name => &$setting) {
-            if (!empty($setting) &&
-                !is_array($setting) &&
+            if (!empty($this->settings[$name]) &&
+                !is_array($this->settings[$name]) &&
                 is_array($this->settingsDefaults[$name])
             ) {
-                $setting = [$setting];
+                $setting = [$this->settings[$name]];
             }
 
-            if ($name == 'taxonomy' && !empty($setting)) {
+            if ($name == 'taxonomy') {
                 foreach ($setting as $taxonomy => &$term) {
                     if (!empty($term) && !is_array($term)) {
                         $term = [$term];
@@ -185,6 +188,7 @@ class Metabox
                 }
             }
         }
+
 
         // Defaults Settings + User Defined Settings.
         $this->settings = array_merge($this->settingsDefaults, $this->settings);
@@ -203,10 +207,12 @@ class Metabox
             return;
         }
 
+
         // Setup fields.
         foreach ($this->fields as $name => $attributes) {
             // Remove array item, only to re-build it below.
             unset($this->fields[$name]);
+
 
             // If Instructions/Snippet
             if (is_int($name) && is_string($attributes)) {
@@ -214,8 +220,10 @@ class Metabox
                 continue;
             }
 
+
             // Set prefixed name.
             $name = $this->settings['prefix'] . $name;
+
 
             // Stored Value.
             $storedValue = get_post_meta($this->postID, $name, true);
@@ -229,15 +237,19 @@ class Metabox
                     $valueArray = is_object($valueArray) ? [$valueArray] : $valueArray;
                 }
             }
-        
+
+
             // Prefix & Merge Attributes with defaults.
             $this->fields[$name] = array_merge($this->fieldDefaults, $attributes);
+
 
             // Subfields.
             if (empty($attributes['subfields'])) {
                 continue;
             }
 
+
+            // Loop Subfields.
             foreach ($attributes['subfields'] as $subName => $subAttributes) {
                 // If Instructions/Snippet
                 if (is_int($subName) && is_string($subAttributes)) {
@@ -245,14 +257,17 @@ class Metabox
                     continue;
                 }
 
+
                 // Prefix & Merge Attributes with defaults.
                 $this->fields[$name]['subfields'][$subName] = array_merge($this->fieldDefaults, $subAttributes);
 
-                // Add Values to subfields.
+
+                // Check if values exists.
                 if (empty($valueArray)) {
                     continue;
                 }
 
+                // Add Values to subfields.
                 foreach ($valueArray as $valueName => $value) {
                     $this->fields[$name]['subfields'][$subName]['values'][] = $value->$subName;
                 }
@@ -267,32 +282,21 @@ class Metabox
      */
     private function addCDNAssets()
     {
-        add_action(
-            'admin_enqueue_scripts',
-            function () {
-                // Remove Old ACF Versions of Select2
-                wp_deregister_script('select2');
-                wp_deregister_style('select2');
+        add_action('admin_enqueue_scripts', function () {
 
-                // Add styles to administrator area.
-                wp_register_style(
-                    'select2-css',
-                    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css',
-                    false,
-                    '4.0.3'
-                );
-                wp_enqueue_style('select2-css');
+            // Remove Old ACF Versions of Select2
+            wp_deregister_script('select2');
+            wp_deregister_style('select2');
 
-                // Add script to administrator area.
-                wp_enqueue_script(
-                    'select2-js',
-                    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js',
-                    ['jquery', 'jquery-ui-sortable'],
-                    null,
-                    false
-                );
-            }
-        );
+
+            // Add styles to administrator area.
+            wp_register_style('select2-css', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css', false, '4.0.3');
+            wp_enqueue_style('select2-css');
+
+
+            // Add script to administrator area.
+            wp_enqueue_script('select2-js', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js', ['jquery', 'jquery-ui-sortable'], null, false);
+        });
     }
 
 
@@ -302,12 +306,9 @@ class Metabox
      */
     private function assetsHeader()
     {
-        add_action(
-            'admin_head',
-            function () {
-                echo file_get_contents(dirname(__FILE__). '/assets/metabox-styles.css');
-            }
-        );
+        add_action('admin_head', function () {
+            echo file_get_contents(dirname(__FILE__). '/assets/metabox-styles.css');
+        });
     }
 
 
@@ -317,15 +318,9 @@ class Metabox
      */
     private function assetsFooter()
     {
-        add_action(
-            'admin_footer',
-            function () {
-                echo '<script>';
-                echo file_get_contents(dirname(__FILE__) . '/assets/metabox-scripts.js');
-                echo '</script>';
-            },
-            20
-        );
+        add_action('admin_footer', function () {
+            echo '<script>' . file_get_contents(dirname(__FILE__) . '/assets/metabox-scripts.js') . '</script>';
+        }, 20);
     }
 
 
@@ -339,18 +334,14 @@ class Metabox
      */
     private function removeWPFeatures()
     {
-        if (empty($this->settings['remove'])) {
-            return;
-        }
-
+        // Remove Features.
         foreach ($this->settings['remove'] as $feature) {
             remove_post_type_support(get_post_type($this->postID), $feature);
         }
 
+
         // Remove Spacing Issue
-        if (in_array('title', $this->settings['remove']) &&
-            in_array('editor', $this->settings['remove'])
-        ) {
+        if (in_array('title', $this->settings['remove']) && in_array('editor', $this->settings['remove'])) {
             echo '<style>#post-body-content { display:none; }</style>';
         }
     }
@@ -366,6 +357,7 @@ class Metabox
     private function initMetabox()
     {
         add_action('add_meta_boxes', function () {
+
             // Add Metabox.
             add_meta_box(
                 'custom-metabox-' . $this->settings['id'],
@@ -376,15 +368,13 @@ class Metabox
                 $this->settings['priority']
             );
 
+
             // Add dependency class to metabox container to initially hide.
             if (!empty($this->settings['dependency'])) {
-                add_filter(
-                    'postbox_classes_' . get_post_type($this->postID) . '_custom-metabox-' . $this->settings['id'],
-                    function ($classes) {
-                        $classes[] = 'data-dependency-key';
-                        return $classes;
-                    }
-                );
+                add_filter('postbox_classes_' . get_post_type($this->postID) . '_custom-metabox-' . $this->settings['id'], function ($classes) {
+                    $classes[] = 'data-dependency-key';
+                    return $classes;
+                });
             }
         });
     }
@@ -399,26 +389,28 @@ class Metabox
         // Add nonce for security and authentication.
         wp_nonce_field($this->nonceAction, $this->nonceName);
 
+
         // Condition Dependency.
         if (!empty($this->settings['dependency'])) {
             $condition  = ' data-dependency-key="' . $this->settings['dependency']['key'] . '"';
             $condition .= ' data-dependency-value=\'' . $this->settings['dependency']['value'] . '\'';
             $condition .= ' data-dependency-condition="' . $this->settings['dependency']['condition'] . '"';
 
-            echo '<span data-key="custom-metabox-' . $this->settings['id'] . '" 
-                        data-type="metabox" 
-                        ' . $condition . '></span>';
+            echo '<span data-key="custom-metabox-' . $this->settings['id'] . '" data-type="metabox" ' . $condition . '></span>';
         }
+
 
         // Show metabox instructions.
         if (!empty($this->settings['instructions'])) {
             echo '<div class="instructions">' . $this->settings['instructions'] . '</div>';
         }
 
+
         // Check if fields are empty.
         if (empty($this->fields)) {
             return;
         }
+
 
         $this->getFields();
     }
@@ -444,31 +436,32 @@ class Metabox
                     $condition .= ' data-dependency-condition="' . $attributes['dependency']['condition'] . '"';
                 }
 
+
                 // Field markup.
-                echo '<div class="input-group type-object" 
-                           data-key="' . $name . '" 
-                           data-type="object" 
-                           ' . $condition . '>';
-            
+                echo '<div class="input-group type-object" data-key="' . $name . '" data-type="object" ' . $condition . '>';
+
+
                 // Set label if exists.
                 if (!empty($attributes['label'])) {
                     echo '<span class="label">' . $attributes['label'] . '</span>';
                 }
+
 
                 // Set description if exists.
                 if (!empty($attributes['description'])) {
                     echo '<div class="description">' . $attributes['description'] . '</div>';
                 }
 
+
                 // Subfields.
-                echo '<div data-subfields-container="' . $name . '" 
-                           ' . ($attributes['repeater'] ? 'data-repeater="true"' : '') . '>';
+                echo '<div data-subfields-container="' . $name . '" ' . ($attributes['repeater'] ? 'data-repeater="true"' : '') . '>';
 
                 $count = 1;
 
                 if ($attributes['repeater'] && !empty(reset($attributes['subfields'])['values'])) {
                     $count = count(reset($attributes['subfields'])['values']);
                 }
+
 
                 for ($i = 0; $i < $count; $i++) {
                     echo '<div data-subfields-parent="' . $name . '">';
@@ -480,7 +473,7 @@ class Metabox
                         } else {
                             $subName = $name . '[' . $subName . ']';
                         }
-                        
+
                         // Update Value.
                         $subAttributes['value'] = '';
 
@@ -498,18 +491,20 @@ class Metabox
                     echo '</div>';
                 }
 
+
                 // End of Input Area.
                 echo '</div>';
 
+
                 // If repeater.
                 if ($attributes['repeater']) {
-                    echo '<div class="button-controls">
-                            <button data-subfields-add="' . $name . '" class="button-primary">Add</button>
-                          </div>';
+                    echo '<div class="button-controls"><button data-subfields-add="' . $name . '" class="button-primary">Add</button></div>';
                 }
+
 
                 // End of Field Group.
                 echo '</div>';
+
 
                 // Jump to next field.
                 continue;
@@ -531,11 +526,13 @@ class Metabox
         // Extract field attributes.
         extract($attributes);
 
+
         // HTML/Message Snippet.
         if (!empty($snippet)) {
             echo '<div class="snippet">' . $snippet . '</div>';
             return;
         }
+
 
         // Field exists.
         if (empty($type) || !file_exists(dirname(__FILE__) . '/fields/' . $type . '.php')) {
@@ -543,10 +540,12 @@ class Metabox
             return;
         }
 
+
         // Multiselect, append [] to name.
         if ($type == 'select-multiple') {
             $name .= '[]';
         }
+
 
         // Label html.
         $labelHTML = '';
@@ -555,26 +554,23 @@ class Metabox
             $labelHTML    = '<label for="' . $name . '">' . $label . $requiredHTML . '</label>';
         }
 
+
         // Description html.
         $descriptionHTML = !empty($description) ? '<div class="description">' . $description . '</div>' : '';
 
+
         // Conditional dependency.
         $condition = '';
-
         if (!empty($dependency)) {
             $condition  = ' data-dependency-key="' . $dependency['key'] . '"';
             $condition .= ' data-dependency-value=\'' . $dependency['value'] . '\'';
             $condition .= ' data-dependency-condition="' . $dependency['condition'] . '"';
         }
 
+
         // Field group.
-        echo '<div class="input-group type-' . $type . '" 
-                   data-key="' . $name . '" 
-                   data-type="' . $type . '"
-                   ' . $condition . '>';
-
+        echo '<div class="input-group type-' . $type . '" data-key="' . $name . '" data-type="' . $type . '" ' . $condition . '>';
         include dirname(__FILE__) . '/fields/' . $type . '.php';
-
         echo '</div>';
     }
 
@@ -586,10 +582,12 @@ class Metabox
     private function initSavePost()
     {
         add_action('save_post', function () {
+
             // Validation Check.
             if (!$this->validateSaveRequest()) {
                 return;
             }
+
 
             // Loop through Meta Fields.
             foreach ($this->fields as $name => $attributes) {
@@ -604,7 +602,7 @@ class Metabox
                 }
 
                 // Subfields.
-                if (!empty($attributes['subfields'])) {
+                if (!empty($attributes['subfields']) && is_array($_POST[$name])) {
                     $hasValue = false;
 
                     // If repeater check deeper array.
@@ -646,19 +644,19 @@ class Metabox
                     }
                 }
 
+
                 // Delete Post Meta Fields if Empty.
                 if (empty($_POST[$name]) && $attributes['type'] != 'radio') {
-                    delete_post_meta(
-                        $this->postID,
-                        $name
-                    );
+                    delete_post_meta($this->postID, $name);
                     continue;
                 }
+
 
                 // select2-multiple: Convert Value to Array.
                 if (!empty($attributes['type']) && $attributes['type'] == 'select2-multiple') {
                     $_POST[$name] = explode(',', $_POST[$name]);
                 }
+
 
                 // If is value is array
                 if (is_array($_POST[$name])) {
@@ -674,13 +672,10 @@ class Metabox
                         throw new \Exception('JSON encoding failed with error:' . json_last_error_msg());
                     }
                 }
-                
+
+
                 // Update Post Meta Fields.
-                update_post_meta(
-                    $this->postID,
-                    $name,
-                    $_POST[$name]
-                );
+                update_post_meta($this->postID, $name, $_POST[$name]);
             }
         });
     }
@@ -699,35 +694,42 @@ class Metabox
             return false;
         }
 
+
         // Add nonce for security and authentication
         if (!isset($_POST[$this->nonceName])) {
             return false;
         }
+
 
         // Check if nonce is set & nonce is valid.
         if (!wp_verify_nonce($_POST[$this->nonceName], $this->nonceAction)) {
             return false;
         }
 
+
         // Check if user has permissions to save data.
         if (!current_user_can('edit_post', $this->postID)) {
             return false;
         }
+
 
         // Check if not an autosave.
         if (wp_is_post_autosave($this->postID)) {
             return false;
         }
 
+
         // Check if not a revision.
         if (wp_is_post_revision($this->postID)) {
             return false;
         }
 
+
         // Check if fields are empty.
         if (empty($this->fields)) {
             return false;
         }
+
 
         return true;
     }
@@ -743,63 +745,72 @@ class Metabox
      */
     private function validateSettings()
     {
-        // Check if post is empty.
-        if (empty($this->postID)) {
+        // Check if should be on all.
+        if (empty($this->settings['post_type']) &&
+            empty($this->settings['post']) &&
+            empty($this->settings['parent']) &&
+            empty($this->settings['taxonomy']) &&
+            empty($this->settings['template'])
+        ) {
             return true;
         }
+
+
+        // Check if new page & post type is set.
+        if (empty($this->postID) &&
+            !empty($_GET['post_type']) &&
+            in_array($_GET['post_type'], $this->settings['post_type'])
+        ) {
+            return true;
+        }
+
 
         // Check if Post(s).
-        if (!empty($this->settings['post']) &&
-            in_array($this->postID, $this->settings['post'])
-        ) {
+        if (in_array($this->postID, $this->settings['post'])) {
             return true;
         }
+
 
         // Check if Post Type.
-        if (!empty($this->settings['post_type']) &&
-            in_array(get_post_type($this->postID), $this->settings['post_type'])
-        ) {
+        if (in_array(get_post_type($this->postID), $this->settings['post_type'])) {
             return true;
         }
+
 
         // Check if Parent.
-        if (!empty($this->settings['parent']) &&
-            in_array(wp_get_post_parent_id($this->postID), $this->settings['parent'])
-        ) {
+        if (in_array(wp_get_post_parent_id($this->postID), $this->settings['parent'])) {
             return true;
         }
 
+
+        // Check if Template.
+        if (in_array(get_page_template_slug($this->postID), $this->settings['template'])) {
+            return true;
+        }
+
+
         // Check if settings.taxonomy is set.
-        if (!empty($this->settings['taxonomy'])) {
-            // Loop taxonomies & match terms for post.
-            foreach ($this->settings['taxonomy'] as $taxonomyAllowed => $termsAllowed) {
-                // Get post terms based on taxonomy.
-                $postTerms = get_the_terms($this->postID, $taxonomyAllowed);
+        foreach ($this->settings['taxonomy'] as $taxonomyAllowed => $termsAllowed) {
+            // Get post terms based on taxonomy.
+            $postTerms = get_the_terms($this->postID, $taxonomyAllowed);
 
-                // Check for if post terms.
-                if (is_wp_error($postTerms) || empty($postTerms)) {
-                    continue;
-                }
+            // Check for if post terms.
+            if (is_wp_error($postTerms) || empty($postTerms)) {
+                continue;
+            }
 
-                // Loop through post terms in taxonomy.
-                foreach ($postTerms as $postTerm) {
-                    // Check terms compared to user inputted array of values.
-                    if (in_array($postTerm->slug, $termsAllowed) ||
-                        in_array($postTerm->term_id, $termsAllowed) ||
-                        in_array($postTerm->name, $termsAllowed)
-                    ) {
-                        return true;
-                    }
+            // Loop through post terms in taxonomy.
+            foreach ($postTerms as $postTerm) {
+                // Check terms compared to user inputted array of values.
+                if (in_array($postTerm->slug, $termsAllowed) ||
+                    in_array($postTerm->term_id, $termsAllowed) ||
+                    in_array($postTerm->name, $termsAllowed)
+                ) {
+                    return true;
                 }
             }
         }
 
-        // Check if Template.
-        if (!empty($this->settings['template']) &&
-            in_array(get_page_template_slug($this->postID), $this->settings['template'])
-        ) {
-            return true;
-        }
 
         return false;
     }
@@ -816,6 +827,7 @@ class Metabox
             return true;
         }
 
+
         // Data attribute of callback.
         $data = [
             'postID'     => $this->postID,
@@ -823,6 +835,7 @@ class Metabox
             'value'      => !empty($_POST[$name]) ? $_POST[$name] : '',
             'attributes' => $attributes
         ];
+
 
         // Callback Function, pass in value as data argument.
         return (call_user_func($attributes['callback'], $data) === false) ? false : true;

--- a/review/assets/meta-scripts.js
+++ b/review/assets/meta-scripts.js
@@ -1,0 +1,9 @@
+function confirmResults(message) {
+    var check = confirm(message);
+
+    if (check == true) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/review/assets/meta-styles.css
+++ b/review/assets/meta-styles.css
@@ -1,0 +1,163 @@
+<style>
+
+body {
+  font-family: "Open Sans", "Helvetica Neue", "Helvetica", "Arial";
+  margin: 0;
+}
+
+table {
+  border: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 14px;
+  table-layout: fixed;
+  text-align: left;
+  width: 100%;
+}
+
+tbody td,
+thead th {
+  font-weight: normal;
+  padding: 15px;
+}
+
+thead th {
+  border: 0;
+}
+
+thead th:first-child {
+  background-color: #283840;
+  border-bottom: 1px solid #283840;
+  border-right: 1px solid #283840;
+  color: #ffffff;
+  font-size: 11px;
+  -webkit-font-smoothing: antialiased;
+  -moz-font-smoothing: antialiased;
+  -o-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+  vertical-align: top;
+  width: 325px;
+}
+
+thead th:last-child {
+  border-bottom: 1px solid #DFE8EE;
+  vertical-align: bottom;
+}
+
+tbody td {
+  border-bottom: 1px solid #DFE8EE;
+}
+
+tbody td:first-child {
+  border-right: 1px solid #DFE8EE;
+  background: #F4F8FB;
+  color: #444;
+  text-transform: uppercase;
+}
+
+tfoot td {
+  background-color: #29c38b;
+  color: #ffffff;
+  padding: 15px;
+  text-align: center;
+}
+
+h4 {
+  margin: 10px 0 5px;
+  font-size: 13px;
+}
+
+h5,
+h6 {
+  margin: 0 0 5px;
+  text-transform: uppercase;
+}
+
+h5 {
+  font-size: 12px;
+}
+
+h6  {
+  font-size: 11px;
+}
+
+hr {
+  border: 1px solid #0daf73;
+  margin: 5px 0 20px;
+}
+
+p {
+  margin: 0;
+}
+
+pre {
+  background-color: #F4F8FB;
+  font-size: 12px;
+  padding: 10px;
+  white-space: -moz-pre-wrap;
+  white-space: -o-pre-wrap;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+pre.remove {
+  background-color: #f9e2e2;
+}
+
+pre.update {
+  background-color: #bdefba;
+}
+
+a {
+  color: #439FD4;
+  font-size: 11px;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #6EC0EF;
+}
+
+[class^='btn'] {
+  border: 0;
+  border-radius: 2px;
+  color: #ffffff;
+  display: inline-block;
+  margin: 0 5px 0 0;
+  padding: 10px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+
+.btn-remove {
+  background-color: #c32929;
+}
+
+.btn-back,
+.btn-update {
+  background-color: #0daf73;
+}
+
+.btn-update:hover,
+.btn-back:hover,
+.btn-remove:hover {
+  color: #ffffff;
+}
+
+pre:hover .link-update,
+pre:hover .link-remove {
+  opacity: 1
+}
+
+.link-update,
+.link-remove {
+  float: right;
+  font-family: "Open Sans", "Helvetica Neue", "Helvetica", "Arial";
+  margin: 0 0 0 15px;
+  opacity: 0;
+  text-transform: uppercase;
+  transition: opacity .3s;
+}
+
+</style>

--- a/review/assets/meta-styles.css
+++ b/review/assets/meta-styles.css
@@ -30,7 +30,7 @@ thead th:first-child {
   border-bottom: 1px solid #283840;
   border-right: 1px solid #283840;
   color: #ffffff;
-  font-size: 11px;
+  font-size: 13px;
   -webkit-font-smoothing: antialiased;
   -moz-font-smoothing: antialiased;
   -o-font-smoothing: antialiased;

--- a/review/assets/metabox-scripts.js
+++ b/review/assets/metabox-scripts.js
@@ -1,0 +1,467 @@
+/**
+ * Subfield Repeater Dependencies.
+ */
+(function($) {
+
+    /**
+     * Select2
+     */
+    var refreshSelect2 = function() {
+
+      /**
+       * Select2 Single
+       */
+      if ($('.type-select2 select').length) {
+
+        $(".type-select2 select").select2();
+
+      }
+
+      /**
+       * Select2 Multiple
+       */
+      if ($('.type-select2-multiple select').length) {
+
+        $('.type-select2-multiple select').each(function() {
+
+          // Setup Select/Keep selected order & cache order of initial values.
+          var $select2 = $(this).select2();
+          var defaults = $select2.select2('data');
+          
+          defaults.forEach(function(obj) {
+
+            // vars.
+            var order           = $select2.data('preserved-order') || [];
+            order[order.length] = obj.id;
+
+            // Set data preserved order.
+            $select2.data('preserved-order', order);
+
+          });
+
+          function selectionHandler(e) {
+
+            // vars.
+            var $select2   = $(this);
+            var val        = e.params.data.id;
+            var order      = $select2.data('preserved-order') || [];
+            var $container = $select2.next('.select2-container');
+            var $tags      = $container.find('li.select2-selection__choice');
+            var $input     = $tags.last().next();
+
+            switch (e.type) {
+
+              case 'select2:select':
+
+                order[order.length] = val;
+
+                break;
+
+              case 'select2:unselect':
+
+                var found_index = order.indexOf(val);
+
+                if (found_index >= 0) {
+
+                  order.splice(found_index, 1);
+
+                }
+
+                break;
+
+            }
+
+            // Store for later usage.
+            $select2.data('preserved-order', order);
+
+            // Apply tag order.
+            order.forEach(function (val) {
+
+              var $el = $tags.filter(function (i, tag) {
+
+                return $(tag).data('data').id === val;
+
+              });
+
+              $input.before($el);
+
+            });
+
+            $select2.prev('input').val(order);
+          }
+
+          $select2.on('select2:select select2:unselect', selectionHandler);
+
+        });
+
+      }
+
+    }
+
+    // Initial Select2 Call
+    refreshSelect2();
+
+
+    /**
+     * Data Repeater
+     */
+    if ($('[data-repeater]').length) {
+
+      /**
+       * Update Field Names/Ids/Labels
+       */
+      var updateNames = function(parent) {
+
+        // vars.
+        var $additions = $('[data-subfields-parent="' + parent + '"]');
+        var find       = parent + '\\[\\d\\]';
+
+        // Loop All Repeater Addition Groups.
+        $.each($additions, function(additionIndex) {
+
+          var $inputGroups = $(this).find('.input-group');
+          var replace      = parent + '[' + additionIndex + ']';
+
+          // Loop Inputs in Addition Group.
+          $.each($inputGroups, function() {
+
+            // vars.
+            var $this = $(this);
+            var type  = $this.data('type');
+            var name  = $this.data('key').replace(new RegExp(find, 'g'), replace);
+            var input = type != 'select2-multiple' ? ':input' : ':input[type="hidden"]';
+
+            // Data Key & Name Update.
+            $this.attr('data-key', name);
+            $this.find(input).attr('name', name);
+            
+            // Checkbox/Radio Label & ID Update.
+            if (type == 'radio' || type == 'checkbox') {
+
+              $.each($this.find(input), function () {
+
+                var $this = $(this);
+
+                $this.parent('label').attr('for', name + '-' + $this.val());
+                $this.attr('id', name + '-' + $this.val());
+
+              });
+
+              return;
+
+            }
+            
+            // Label Update.
+            $this.find('label').attr('for', name);
+
+          });
+
+        });
+
+      }
+
+      /**
+       * Add Repeater Addition.
+       */
+      $('[data-subfields-add]').on('click', function(ev) {
+
+        ev.preventDefault();
+
+        // vars.
+        var parentKey           = $(this).data('subfields-add');
+        var $subfieldsContainer = $('[data-subfields-container="' + parentKey + '"]');
+        var buttonHTML          = '<button class="button-remove">&#10005;</button>';
+        var $addtions           = $('[data-subfields-parent="' + parentKey + '"]');
+
+        // Add button if more than 1.
+        if ($addtions.length == 1) {
+
+          $addtions.append(buttonHTML);
+
+        }
+
+        // Append new input group. Set temp input names.
+        var $copy = $addtions.eq(0).clone();
+        $copy.find(':input').attr('name', '');
+        $copy.appendTo($subfieldsContainer);
+
+        // Remove Values, Select2, Editor.
+        var $newAddition = $('[data-subfields-parent="' + parentKey + '"]').last();
+        $newAddition.find(':input').not('[type="radio"], [type="checkbox"]').val('');
+        $newAddition.find('[type="radio"], [type="checkbox"]').prop('checked', false);
+        $newAddition.find('.select2').remove();
+        $newAddition.find('.wp-editor-wrap').html('<div class="notification-error">Repeater WP Editor coming soon, please use textarea for time being.</div>');
+
+        // Update Names.
+        updateNames(parentKey);
+
+        // Refresh Sortable/Select2.
+        $subfieldsContainer.sortable('refresh');
+        refreshSelect2();
+
+      });
+
+
+      /**
+       * Remove Repeater Addition.
+       */
+      $('[data-subfields-container]').on('click', '.button-remove', function(ev) {
+
+        ev.preventDefault();
+
+        // vars.
+        var $parentContainer    = $(this).parents('[data-subfields-parent]');
+        var parentKey           = $parentContainer.data('subfields-parent');
+        var $subfieldsContainer = $('[data-subfields-container="' + parentKey + '"]');
+        var $additions          = $('[data-subfields-parent="' + parentKey + '"]');
+
+         // Don't remove if only one left.
+        if ($additions.length == 1) {
+
+          return;
+
+        }
+
+        // Remove.
+        $parentContainer.remove();
+
+        // Remove button if only 1.
+        if ($additions.length == 2) {
+
+          $additions.find('.button-remove').remove();
+
+        }
+        
+        // Update Names.
+        updateNames(parentKey);
+
+        // Refresh sortable.
+        $subfieldsContainer.sortable('refresh');
+
+      });
+
+      // Sortable on Subfields container. V2
+      $('[data-repeater]').sortable( {
+
+        update: function() {
+
+          updateNames($(this).data('subfields-container'));
+
+        }
+
+      });
+
+    }
+
+  })(jQuery);
+
+
+  /**
+   * Conditional Dependencies.
+   */
+  (function($) {
+
+    if ($('[data-dependency-key]').length) {
+
+      var $dependencyInputs = [];
+
+      /**
+       * Updates Fields on Load/Input Change.
+       */
+      var updateFields = function() {
+
+        $('[data-dependency-key]').each(function(){
+
+          // Declare variables.
+          var $this            = $(this);
+          var key              = $this.data('dependency-key');
+          var value            = typeof $this.data('dependency-value') == 'undefined' ? 0 : $this.data('dependency-value');
+          var condition        = $this.data('dependency-condition') ? $this.data('dependency-condition').toLowerCase() : '';
+          var $dependency      = $('[data-key=' + key + ']');
+          var $dependencyInput = $dependency.find('[name=' + key + ']');
+          var dependencyType   = $dependency.data('type');
+          var dependencyValue  = $dependencyInput.val() && !isNaN($dependencyInput.val()) ? parseInt($dependencyInput.val()) : $dependencyInput.val();
+          var isShown          = false;
+          var valueIsArray     = value instanceof Array ? true : false;
+
+          // Add object to array.
+          $dependencyInputs.push($dependencyInput);
+
+          // Checkbox check.
+          if (dependencyType == 'checkbox') {
+
+            dependencyValue = $dependencyInput.last().is(':checked') ? 1 : 0;
+
+          }
+
+          // Radio check.
+          if (dependencyType == 'radio') {
+
+            dependencyValue = $dependencyInput.filter(':checked').val();
+
+          }
+
+          // Run defined condition check between dependency & given value.
+          switch (condition) {
+
+            case '=':
+            case '==':
+
+              if ((valueIsArray && value.indexOf(dependencyValue) !== -1) || (!valueIsArray && dependencyValue == value)) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case '!=':
+
+              if ((valueIsArray && value.indexOf(dependencyValue) === -1) || (!valueIsArray && dependencyValue != value)) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case '>=':
+
+              if (dependencyValue >= value) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case '<=':
+
+              if (dependencyValue <= value) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case '>':
+
+              if (dependencyValue > value) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case '<':
+
+              if (dependencyValue < value) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case 'between':
+
+              if (valueIsArray && dependencyValue > value[0] && dependencyValue < value[1]) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case 'outside':
+
+              if (valueIsArray && (dependencyValue < value[0] || dependencyValue > value[1])) {
+
+                isShown = true;
+
+              }
+
+              break;
+
+            case 'contains':
+
+              if (dependencyValue.indexOf(value) !== -1) {
+
+                isShown = true;
+
+              }
+
+              break;
+          }
+
+          // Check if dependency is hidden, then don't show.
+          if ($dependency.data('hidden') == true) {
+
+            isShown = false;
+
+          }
+
+          // Select2/Select multiple check. Not Available, so show field.
+          if (dependencyType == 'select2-multiple' || dependencyType == 'select-multiple') { 
+
+            alert('NOTICE: Dependencies are not available for MULTIPLE OPTION SELECTS.');
+            isShown = true;
+
+          }
+
+          // If not shown, hide siblings dependencies.
+          if (isShown) {
+
+            $this.data('hidden', false);
+
+            // Metabox show.
+            if ($this.data('type') == 'metabox') {
+
+              $this.parents('#' + $this.data('key')).show();
+              return;
+
+            }
+
+            // Field show.
+            $this.show();
+
+          } else {
+
+            $this.data('hidden', true);
+
+            // Metabox hide.
+            if ($this.data('type') == 'metabox') {
+
+              $this.parents('#' + $this.data('key')).hide();
+              return;
+
+            }
+
+            // Field hide.
+            $this.hide();
+
+          }
+
+        });
+
+      }
+
+      // Initial Update Fields Call
+      updateFields();
+
+      // Bind Change Event to Dependency Inputs
+      $.each($dependencyInputs, function(){
+
+        $(this).on('change', function(){
+
+          updateFields();
+
+        });
+
+      });
+
+    }
+
+})(jQuery);

--- a/review/assets/metabox-styles.css
+++ b/review/assets/metabox-styles.css
@@ -1,0 +1,300 @@
+<style>
+
+[id^="custom-metabox"] {
+  font-size: 13px;
+}
+
+#poststuff [id^="custom-metabox"] .inside {
+  margin-top: 13px;
+}
+
+[id^="custom-metabox"] .snippet,
+[id^="custom-metabox"] .input-group {
+  margin-top: 13px;
+}
+
+[id^="custom-metabox"] .input-group {
+  font-size: 14px;
+}
+
+[id^="custom-metabox"] .input-group[data-dependency-key],
+.data-dependency-key {
+  display: none;
+}
+
+/* Snippet */
+[id^="custom-metabox"] .snippet hr {
+  margin: 24px 0 15px
+}
+
+/* Instructions */
+[id^="custom-metabox"] .instructions {
+  background: #f5f5f5;
+  border-radius: 1px;
+  display: block;
+  font-size: 11px;
+  margin: 5px 0;
+  padding: 7px;
+}
+
+/* Labels */
+[id^="custom-metabox"] label,
+[id^="custom-metabox"] .label {
+  cursor: default;
+  display: block;
+  font-size: 11px;
+  font-weight: bold;
+  margin-bottom: 3px;
+  margin-top: 13px;
+  text-transform: uppercase;
+}
+
+[id^="custom-metabox"] .type-checkbox label,
+[id^="custom-metabox"] .type-radio label {
+  cursor: pointer;
+}
+
+/* Inputs */
+[id^="custom-metabox"] input[type="text"],
+[id^="custom-metabox"] input[type="email"],
+[id^="custom-metabox"] input[type="date"],
+[id^="custom-metabox"] input[type="number"],
+[id^="custom-metabox"] input[type="tel"],
+[id^="custom-metabox"] input[type="range"],
+[id^="custom-metabox"] input[type="url"],
+[id^="custom-metabox"] textarea,
+[id^="custom-metabox"] select,
+[id^="custom-metabox"] .input-datalist {
+  appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, .07);
+  display: block;
+  height: 36px;
+  line-height: 24px;
+  margin: 0;
+  padding: 5px 10px;
+  width: 100%;
+}
+
+[id^="custom-metabox"] input[readonly],
+[id^="custom-metabox"] .input-datalist[readonly],
+[id^="custom-metabox"] textarea[readonly] {
+  background-color: #f7f7f7;
+  cursor: not-allowed;
+}
+
+[id^="custom-metabox"] select[multiple],
+[id^="custom-metabox"] textarea {
+  height: 120px;
+}
+
+[id^="custom-metabox"] textarea {
+  padding: 10px;
+}
+
+/* Input - Select Multiple */
+[id^="custom-metabox"] select[multiple] {
+  padding: 0;
+}
+
+
+[id^="custom-metabox"] .type-select select {
+  background-color: #fff;
+  background-image: url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22276.7%22%20height%3D%22153%22%20viewBox%3D%220%200%20276.7%20153%22%20enable-background%3D%22new%200%200%20276.7%20153%22%3E%3Cstyle%3E.arrow%7Bfill%3A%23393939%3B%7D%3C%2Fstyle%3E%3Cpath%20class%3D%22arrow%22%20d%3D%22M276.7%200H0l138.2%20153z%22%20%2F%3E%3C%2Fsvg%3E);
+  background-position: right 12px center;
+  background-repeat: no-repeat;
+  background-size: auto 5px;
+  padding: 0 32.5px 0 10px;
+}
+
+[id^="custom-metabox"] .type-select select::-ms-expand {
+  display: none;
+}
+
+[id^="custom-metabox"] select[multiple] option {
+  background: #f5f5f5;
+  border-bottom: 1px solid #ffffff;
+  padding: 5px 10px;
+}
+
+/* Input - Radio/Checkbox */
+[id^="custom-metabox"] .type-radio label,
+[id^="custom-metabox"] .type-checkbox label {
+  font-size: 13px;
+  font-weight: normal;
+  padding-left: 26px;
+  position: relative;
+  text-transform: none;
+}
+
+[id^="custom-metabox"] .type-radio label input,
+[id^="custom-metabox"] .type-checkbox label input {
+  left: 0;
+  position: absolute;
+  top: 6px;
+}
+
+[id^="custom-metabox"] .type-radio label {
+  margin-top: 5px;
+}
+
+/* Input - Select2 */
+[id^="custom-metabox"] .select2-container--default .select2-selection--multiple,
+[id^="custom-metabox"] .select2-container--default .select2-selection--single {
+  border: 1px solid #ddd;
+  border-radius: 0;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, .07);
+  background-color: #fff;
+  color: #32373c;
+  min-height: 36px;
+  outline: 0;
+  transition: 50ms border-color ease-in-out;
+}
+
+[id^="custom-metabox"] .select2-container--default.select2-container--focus .select2-selection--multiple,
+[id^="custom-metabox"] .select2-container--default.select2-container--focus .select2-selection--single {
+  border-color: #5b9dd9;
+  box-shadow: 0 0 2px rgba(30,140,190, .8);
+}
+[id^="custom-metabox"] .select2-container--default .select2-selection--multiple .select2-selection__choice {
+ background-color: #f5f5f5;
+ border-color: #e4e4e4;
+ padding: 5px 10px;
+}
+
+[id^="custom-metabox"] .select2-container--default .select2-selection--multiple .select2-search--inline .select2-search__field {
+  margin-top: 12px !important;
+  margin-bottom: 6px;
+}
+
+[id^="custom-metabox"] .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  margin-right: 5px;
+}
+
+[id^="custom-metabox"] .select2-dropdown {
+  border: 1px solid #ddd;
+  border-radius: 0;
+}
+
+[id^="custom-metabox"] .select2-results__option {
+  border-bottom: 1px solid #ffffff;
+}
+
+[id^="custom-metabox"] .select2-container--default .select2-selection--single .select2-selection__rendered {
+  line-height: 36px;
+  padding-left: 10px;
+  padding-right: 32px;
+}
+
+[id^="custom-metabox"] .select2-container--default .select2-selection--single .select2-selection__arrow {
+  height: 34px;
+  right: 7px;
+}
+
+[id^="custom-metabox"] .select2-container--default .select2-selection--single .select2-selection__arrow b {
+  border-color: #393939 transparent transparent transparent;
+}
+
+[id^="custom-metabox"] .select2-container--default.select2-container--open .select2-selection--single .select2-selection__arrow b {
+  border-color: transparent transparent #393939 transparent;
+}
+
+/* Buttons */
+[id^="custom-metabox"] .button-controls {
+  margin-bottom: 0;
+  text-align: right;
+}
+
+/* Notifications */
+[id^="custom-metabox"] [class*="notification"] {
+  background: #f5f5f5;
+  border-radius: 1px;
+  display: block;
+  font-size: 11px;
+  margin: 5px 0;
+  padding: 7px;
+}
+
+[id^="custom-metabox"] [class*="notification-error"] {
+  color: #bf2d2d;
+  margin: 15px 0 5px;
+}
+
+/* Subfields */
+[data-subfields-parent] {
+  background-color: #f4f4f4;
+  border: 1px solid #d4d4d4;
+  border-top: 0;
+  padding: 1px 15px 15px;
+  position: relative;
+}
+
+[data-subfields-parent]:first-child {
+  border: 1px solid #d4d4d4;
+}
+
+/* Repeater Subfields */
+[data-repeater="true"] {
+  counter-reset: section;
+}
+
+[data-repeater="true"] [data-subfields-parent] {
+  padding-left: 45px;
+}
+
+[data-repeater="true"] [data-subfields-parent]::before {
+  background: #e2e2e2;
+  border-right: 1px solid #d4d4d4;
+  counter-increment: section;
+  content: counter(section);
+  cursor: move;
+  color: #797979;
+  bottom: 0;
+  display: block;
+  font-size: 11px;
+  font-weight: bold;
+  height: 100%;
+  left: 0;
+  line-height: 45px;
+  position: absolute;
+  text-align: center;
+  text-shadow: white 0 1px 0;
+  top: 0;
+  vertical-align: middle;
+  width: 32px;
+}
+
+[data-repeater="true"] [data-subfields-parent] .button-remove {
+  background-color: white;
+  border: 1px solid #dddddd;
+  border-radius: 50%;
+  color: #72777c;
+  cursor: pointer;
+  opacity: 0;
+  font-size: 12px;
+  height: 25px;
+  right: -12px;
+  line-height: 1;
+  outline: 0;
+  padding: 0;
+  position: absolute;
+  text-align: center;
+  top: 0;
+  transform: translateY(-50%);
+  transition: opacity .2s;
+  width: 25px;
+}
+
+[data-repeater="true"] [data-subfields-parent]:hover .button-remove {
+  opacity: 1;
+}
+
+[data-repeater="true"] [data-subfields-parent] .button-remove:hover {
+  background-color: #dddddd;
+  color: white;
+}
+
+</style>

--- a/review/fields/_datalist.php
+++ b/review/fields/_datalist.php
@@ -1,0 +1,29 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $value ? ' value="' . $value . '"' : '';
+$attributes .= $placeholder ? ' placeholder="' . $placeholder . '"' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $required ? ' required' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+$attributes .= ' class="input-datalist"';
+
+?>
+
+<input list="<?php echo $name; ?>" name="<?php echo $name; ?>"  <?php $attributes; ?> />
+
+<datalist id="<?php echo $name; ?>">
+
+    <?php
+    foreach ($options as $optionLabel => $optionValue) :
+        $selected = $optionValue == $value ? ' selected="selected"' : '';
+    ?>
+
+    <option value="<?php echo $optionValue; ?>" <?php echo $selected; ?>><?php echo $optionLabel; ?></option>
+
+    <?php endforeach; ?>
+
+</datalist>

--- a/review/fields/checkbox.php
+++ b/review/fields/checkbox.php
@@ -1,0 +1,16 @@
+<?php
+
+echo $descriptionHTML;
+
+$attributes = !empty($value) ? ' checked="checked"' : '';
+
+?>
+
+<label for="<?php echo $name; ?>">
+
+    <input type="hidden" name="<?php echo $name; ?>" value="0" />
+    <input type="checkbox" id="<?php echo $name; ?>" name="<?php echo $name; ?>" value="1" <?php echo $attributes; ?>/>
+
+    <?php echo $label; ?>
+
+</label>

--- a/review/fields/date.php
+++ b/review/fields/date.php
@@ -1,0 +1,15 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $value ? ' value="' . $value . '"' : '';
+$attributes .= $required ? ' required' : '';
+$attributes .= $placeholder ? ' placeholder="' . $pattern . '"' : '';
+$attributes .= $pattern ? ' pattern="' . $pattern . '"' : '';
+$attributes .= $style ? ' style="' . $style . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+
+?>
+
+<input type="date" name="<?php echo $name; ?>" <?php echo $attributes; ?> />

--- a/review/fields/editor.php
+++ b/review/fields/editor.php
@@ -1,0 +1,16 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+wp_editor(
+    esc_textarea($value),
+    'he-editor-' . rand(1, 1000000),
+    array(
+        'textarea_name'  => $name,
+        'media_buttons'  => true,
+        'editor_height'  => 200,
+        'tinymce'        => true,
+        'quicktags'      => true
+    )
+);

--- a/review/fields/email.php
+++ b/review/fields/email.php
@@ -1,0 +1,16 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $value ? ' value="' . esc_attr($value) . '"' : '';
+$attributes .= $style ? ' style="' . $style . '"' : '';
+$attributes .= $placeholder ? ' placeholder="' . $placeholder . '"' : '';
+$attributes .= $pattern ? ' pattern="' . $pattern . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $required ? ' required' : '';
+    
+?>
+
+<input type="email" name="<?php echo $name; ?>" <?php echo $attributes; ?> />

--- a/review/fields/number.php
+++ b/review/fields/number.php
@@ -1,0 +1,19 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $value ? ' value="' . esc_attr($value) . '"' : '';
+$attributes .= $style ? ' style="' . $style . '"' : '';
+$attributes .= $placeholder ? ' placeholder="' . $placeholder . '"' : '';
+$attributes .= $pattern ? ' pattern="' . $pattern . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $min ? ' min="' . $min . '"' : '';
+$attributes .= $max ? ' max="' . $max . '"' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $required ? ' required' : '';
+
+?>
+
+<input type="number" name="<?php echo $name; ?>" <?php echo $attributes; ?>/>

--- a/review/fields/radio.php
+++ b/review/fields/radio.php
@@ -1,0 +1,27 @@
+<?php
+
+if (!empty($label)) {
+    echo '<span class="label">' . $label . ($required ? '<span class="required">*</span>' : '') . '</span>';
+}
+
+echo $description;
+
+foreach ($options as $optionLabel => $optionValue) :
+    $checked = $optionValue == $value ? ' checked="checked"' : '';
+    $id      = $name . '-' . $optionValue;
+
+    ?>
+
+    <label for="<?php echo $id; ?>">
+
+    <input type="radio" 
+           name="<?php echo $name; ?>"
+           id="<?php echo $id; ?>" 
+           value="<?php echo $optionValue; ?>" 
+            <?php echo $checked; ?> />
+           
+    <?php echo $optionLabel; ?>
+        
+    </label>
+
+<?php endforeach;

--- a/review/fields/select-multiple.php
+++ b/review/fields/select-multiple.php
@@ -1,0 +1,26 @@
+<?php
+
+if (!empty($label)) {
+    echo '<label for="' . $name . '">' . $label . ($required ? '<span class="required">*</span>' : '') . '</label>';
+}
+
+echo $descriptionHTML;
+
+$valueArray = is_array($value) ? $value : json_decode($value, true);
+$attributes = $style ? ' style="' . $style . '"' : '';
+$attributes .= $required ? ' required' : '';
+
+?>
+
+<select name="<?php echo $name; ?>" multiple="multiple" <?php echo $attributes; ?>>
+
+    <?php
+    foreach ($options as $optionLabel => $optionValue) :
+        $selected = !empty($valueArray) && in_array($optionValue, $valueArray) ? 'selected="selected"' : '';
+    ?>
+
+    <option value="<?php echo $optionValue; ?>" <?php echo $selected; ?>><?php echo $optionLabel; ?></option>
+    
+    <?php endforeach; ?>
+
+</select>

--- a/review/fields/select.php
+++ b/review/fields/select.php
@@ -1,0 +1,22 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $style ? ' style="' . $style . '"' : '';
+$attributes .= $required ? ' required' : '';
+
+?>
+
+<select name="<?php echo $name; ?>" <?php echo $attributes; ?>>
+
+    <?php
+    foreach ($options as $optionLabel => $optionValue) :
+        $selected = $optionValue == $value ? 'selected="selected"' : '';
+    ?>
+
+   <option value="<?php echo $optionValue; ?>" <?php echo $selected; ?>><?php echo $optionLabel; ?></option>
+
+    <?php endforeach; ?>
+
+</select>

--- a/review/fields/select2-multiple.php
+++ b/review/fields/select2-multiple.php
@@ -1,0 +1,39 @@
+<?php
+   
+echo $labelHTML;
+echo $descriptionHTML;
+
+$valueArray  = is_array($value) ? $value : json_decode($value, true);
+$valueString = !empty($valueArray) ? implode(',', $valueArray) : '';
+$attributes  = $required ? ' required' : '';
+
+?>
+
+<input name="<?php echo $name; ?>" value="<?php echo $valueString; ?>" type="hidden" tabindex="-1" />
+
+<select style="width: 100%;" multiple="multiple" <?php echo $attributes; ?>>
+    
+    <?php
+    if (!empty($valueArray)) :
+        foreach ($valueArray as $value) :
+            $optionLabel = array_search($value, $options);
+    ?>
+
+            <option value="<?php echo $value; ?>" selected="selected"><?php echo $optionLabel; ?></option>
+            <?php unset($options[$optionLabel]); ?>
+    
+    <?php
+        endforeach;
+    endif;
+
+    foreach ($options as $optionLabel => $optionValue) :
+        if (empty($optionValue)) {
+            continue;
+        }
+    ?>
+
+    <option value="<?php echo $optionValue; ?>"><?php echo $optionLabel; ?></option>
+
+    <?php endforeach; ?>
+
+</select>

--- a/review/fields/select2.php
+++ b/review/fields/select2.php
@@ -1,0 +1,22 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $required ? ' required' : '';
+$attributes .= ' style="width: 100%;"';
+    
+?>
+
+<select name="<?php echo $name; ?>" <?php echo $attributes; ?>>
+    
+    <?php
+    foreach ($options as $optionLabel => $optionValue) :
+        $selected = $optionValue == $value ? 'selected="selected"' : '';
+    ?>
+
+    <option value="<?php echo $optionValue; ?>" <?php echo $selected; ?>><?php echo $optionLabel; ?></option>
+
+    <?php endforeach; ?>
+
+</select>

--- a/review/fields/tel.php
+++ b/review/fields/tel.php
@@ -1,0 +1,16 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $value ? ' value="' . esc_attr($value) . '"' : '';
+$attributes .= $style ? ' style="' . $style . '"' : '';
+$attributes .= $placeholder ? ' placeholder="' . $placeholder . '"' : '';
+$attributes .= $pattern ? ' pattern="' . $pattern . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $required ? ' required' : '';
+
+?>
+
+<input type="tel" name="<?php echo $name; ?>" <?php echo $attributes; ?>/>

--- a/review/fields/text.php
+++ b/review/fields/text.php
@@ -1,0 +1,16 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $value ? ' value="' . esc_attr($value) . '"' : '';
+$attributes .= $style ? ' style="' . $style . '"' : '';
+$attributes .= $placeholder ? ' placeholder="' . $placeholder . '"' : '';
+$attributes .= $pattern ? ' pattern="' . $pattern . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $required ? ' required' : '';
+
+?>
+
+<input type="text" name="<?php echo $name; ?>" <?php echo $attributes; ?>/>

--- a/review/fields/textarea.php
+++ b/review/fields/textarea.php
@@ -1,0 +1,12 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $style ? ' style="' . $style . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+$attributes .= $required ? ' required' : '';
+    
+?>
+
+<textarea name="<?php echo $name; ?>" <?php echo $attributes; ?>><?php echo esc_textarea($value); ?></textarea>

--- a/review/fields/url.php
+++ b/review/fields/url.php
@@ -1,0 +1,16 @@
+<?php
+
+echo $labelHTML;
+echo $descriptionHTML;
+
+$attributes  = $value ? ' value="' . esc_attr($value) . '"' : '';
+$attributes .= $style ? ' style="' . $style . '"' : '';
+$attributes .= $placeholder ? ' placeholder="' . $placeholder . '"' : '';
+$attributes .= $pattern ? ' pattern="' . $pattern . '"' : '';
+$attributes .= $readonly ? ' readonly' : '';
+$attributes .= $maxlength ? ' maxlength="' . $maxlength . '"' : '';
+$attributes .= $required ? ' required' : '';
+
+?>
+
+<input type="url" name="<?php echo $name; ?>" <?php echo $attributes; ?>/>

--- a/review/plugins/pluginCSV.php
+++ b/review/plugins/pluginCSV.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Plugin - CSV : 'csv_json_{metakey}'
+ * Uses CsvImporter class to grab and parse csv file.
+ *
+ */
+function pluginCSV($data)
+{
+    $postID = $_POST['post_ID'];
+    $name   = $data['name'];
+    $value  = !empty($_POST[$name]) ? $_POST[$name] : $data['value'];
+
+    // No Meta Key.
+    if (empty($name)) {
+        return;
+    }
+
+    // Check for Value.
+    if (!empty($value)) {
+        // Init Class.
+        $csv = new \CsvImporter();
+
+        // Determine if remote or local.
+        if (filter_var($value, FILTER_VALIDATE_URL)) {
+            $csv->Remote = $value;
+        } else {
+            $csv->Local = WP_CONTENT_DIR . str_replace('/wp-content', '', $value);
+        }
+
+        // Get CSV
+        $value = $csv->get();
+    }
+    
+    // # Delete meta if $metavalue or CSV Import is empty.
+    if (empty($value)) {
+        delete_post_meta($postID, 'csv_json_' . str_replace('csv_url_', '', $name));
+        return;
+    }
+
+    // # Save CSV JSON
+    update_post_meta($postID, 'csv_json_' . str_replace('csv_url_', '', $name), wp_slash($value));
+}

--- a/review/views/meta-dashboard.php
+++ b/review/views/meta-dashboard.php
@@ -1,0 +1,244 @@
+<table class="metabox-results">
+    <thead>
+        <tr>
+            <th>
+                <h3>Meta Class</h3>
+                <h4>$meta = new Meta();</h4>
+                <p>Add `?meta=1` to url, to setup UI.</p>
+                <h4>$meta->setMeta();</h4>
+                <p>$meta->setMeta(array(
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'meta_key' => 'meta_value',
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'meta_key' => array('meta_value', 'new_value'),
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'meta_key',
+                <br />));</p>
+                <h4>$meta->setQuery();</h4>
+                <p>$meta->setQuery(array(
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'posts' => array('343', 234, 12),
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'post_type' => array('post', 'cpt_post'),
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'parents' => array(45, 234, '23'),
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'taxonomy' => array( taxonomy => array('term_1', 'term_2')),
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'templates' => array('front-page.php'),
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'slug' => 'page-slug-name',
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'wp_args' => refer to $args for WP_Query.
+                <br />));</p>
+                <h4>$meta->init();</h4>
+                <p>Shows the results with defined fields &amp; query set.</p>
+            </th>
+            <th>
+
+                <h5>Meta</h5>
+                <?php
+
+                $hasUpdates  = false;
+                    
+                // Meta loop.
+                if (!empty($this->meta)) {
+                    foreach ($this->meta as $key => $value) {
+                        $valueHTML = is_array($value) ? $value[0] . ' => ' . $value[1] : $value;
+                        echo '<pre><strong>' . $key . '</strong> = ' . $valueHTML . '</pre>';
+
+                        // If has updates.
+                        if (is_array($value) && !$hasUpdates) {
+                            $hasUpdates = true;
+                        }
+                    }
+                } else {
+                    echo '<pre>Meta data not set.</pre>';
+                }
+
+                ?>
+                <hr />
+
+                <h5>Query</h5>
+                <?php
+
+                $hasSettings = false;
+
+                // Loop Queries.
+                foreach ($this->query as $setting => $value) {
+                    if (empty($value)) {
+                        continue;
+                    }
+
+                    $hasSettings = true;
+
+                    echo '<h6>' . $setting . '</h6>';
+                    echo '<pre>';
+                    echo is_array($value) ? print_r($value) : $value;
+                    echo '</pre>';
+                }
+
+                // Has no settings.
+                if (!$hasSettings) {
+                    echo '<pre>Query arguments not set, all post(s) queried.</pre>';
+                }
+
+                ?>
+                <hr />
+
+                <h5>Results</h5>
+                <?php
+
+                // Count, Results || Posts, if not 0 posts.
+                if (!empty($this->results)) {
+                    echo '<pre>' . count($this->results) . ' Post(s) Effected</pre>';
+                } elseif (!empty($this->posts) && empty($_GET['action'])) {
+                    echo '<pre>' . count($this->posts) . ' Post(s)</pre>';
+                } else {
+                    echo '<pre>0 Post(s)</pre>';
+                }
+
+                // Actions.
+                if (empty($_GET['action']) && !empty($this->posts)) {
+                    if ($hasUpdates) {
+                        $messageUpdate = '\'Update Meta from all ' . count($this->posts) . ' post(s)?\'';
+                        echo '<a class="btn-update" 
+                                 onclick="return confirmResults(' . $messageUpdate . ')" 
+                                 href="' . home_url() . '?meta=1&id=all&action=update">Update All Meta Results</a>';
+                    }
+                    if (!empty($this->meta)) {
+                        $messageRemove = '\'Remove Meta from all ' . count($this->posts) . ' post(s)?\'';
+                        echo '<a class="btn-remove"
+                                     onclick="return confirmResults(' . $messageRemove . ')" 
+                                     href="' . home_url() . '?meta=1&id=all&action=remove">Remove All Meta Results</a>';
+                    }
+                }
+
+                // Back.
+                if (!empty($_GET['id'])) {
+                    echo '<a class="btn-back" href="' . home_url() . '?meta=1">Back</a>';
+                }
+
+                ?>
+            </th>
+        </tr>
+    </thead>
+
+    <tfoot>
+        <tr>
+            <td colspan="2">Remove `init` method or `?meta=1` from url to exit this screen.</td>
+        </tr>
+    </tfoot>
+
+    <?php
+
+    // Results.
+    if (!empty($this->results)) :
+        foreach ($this->results as $post_id => $meta) :
+    ?> 
+        <tr>
+            <td>
+                <strong><?php echo $this->posts[$post_id]; ?> </strong><br />
+                <strong>ID: </strong><?php echo $post_id; ?> <br /><br />
+                <a href="<?php echo get_permalink($post_id); ?>">View Post</a> - 
+                <a href="<?php echo admin_url('post.php?post=' . $post_id . '&action=edit'); ?>">Edit Post</a>
+            </td>
+            <td>
+            <?php
+
+            if (!empty($meta)) {
+                foreach ($meta as $key => $value) {
+                    echo '<pre class="' . $_GET['action'] . '"><strong>' . $key . '</strong> = ';
+
+                    if ($_GET['action'] == 'remove') {
+                        echo is_array($value) ? $value[0] : $value;
+                    } elseif ($_GET['action'] == 'update' && is_array($value)) {
+                        echo $value[0] . ' => ' . $value[1];
+                    }
+
+                    echo '</pre>';
+                }
+            }
+
+            ?>
+            </td>
+            <tr>
+    <?php
+        endforeach;
+    elseif (!empty($this->posts) && empty($_GET['action'])) :
+        foreach ($this->posts as $post_id => $title) :
+            $metaHTML  = '';
+            $hasUpdate = false;
+
+            // Meta values.
+            if (!empty($this->meta)) {
+                foreach ($this->meta as $key => $value) {
+                    // Setup key & get stored value.
+                    $definedValue = is_array($value) ? $value[0] : $value;
+                    $storedValue  = get_post_meta($post_id, $key, true);
+
+                    if ((metadata_exists('post', $post_id, $key)) &&
+                        ($storedValue || $storedValue == '0' || $storedValue == '') &&
+                        ($definedValue == '*' || $definedValue == $storedValue)
+                    ) {
+                        $metaHTML .= '<pre>';
+                        $metaHTML .= '<strong>' . $key . '</strong> = ' . $storedValue;
+
+                        // Remove link.
+                        $messageRemove = '\'Remove ' . strtoupper($key) . ' from ' . $title . '?\'';
+                        $metaHTML .= ' <a class="link-remove" 
+                                          href="' . home_url() . '?meta=1&id=' . $post_id . '&metakey=' . $key . '&metavalue=' . $storedValue . '&action=remove" 
+                                          onclick="return confirmResults(' . $messageRemove . ')">Remove</a>';
+
+                        // Update link.
+                        if (is_array($value)) {
+                            $hasUpdate = true;
+                            $messageUpdate = '\'Update ' . strtoupper($key) . ' from ' . $title . '?\'';
+                            $metaHTML .= ' <a class="link-update" 
+                                              href="' . home_url() . '?meta=1
+                                              &id=' . $post_id . '
+                                              &metakey=' . $key . '
+                                              &metavalue=' . $storedValue . '
+                                              &value=' . $value[1] . '
+                                              &action=update" 
+                                              onclick="return confirmResults(' . $messageUpdate . ')">Update</a>';
+                        }
+
+                        $metaHTML .= '</pre>';
+                    }
+                }
+            } else {
+                // Show all metafields.
+                $meta = get_post_meta($post_id);
+
+                foreach ($meta as $key => $value) {
+                    $messageRemove ='\'Remove ' . strtoupper($key) . ' from ' . $title . '?\'';
+                    $metaHTML .= '<pre>';
+                    $metaHTML .= '<strong>' . $key . '</strong> = ' . $value[0];
+                    $metaHTML .= ' <a class="link-remove" 
+                                          href="' . home_url() . '?meta=1&id=' . $post_id . '&metakey=' . $key . '&metavalue=' . $value[0] . '&action=remove" 
+                                          onclick="return confirmResults(' . $messageRemove . ')">Remove</a>';
+                    $metaHTML .= '</pre>';
+                }
+            }
+
+        ?> 
+
+        <tr>
+            <td>
+                <strong><?php echo $title; ?></strong><br />
+                <strong>ID: </strong><?php echo $post_id; ?><br /><br />
+                <a href="<?php echo get_permalink($post_id); ?>">View</a> 
+                - <a href="<?php echo admin_url('post.php?post=' . $post_id . '&action=edit'); ?>">Edit</a>
+                <?php
+
+                if (!empty($this->meta)) {
+                    if ($hasUpdate) {
+                        $messageUpdate = '\'Update Meta from ' . $title . '?\'';
+                        echo ' - <a href="' . home_url() . '?meta=1&id=' . $post_id . '&action=update" 
+                                    onclick="return confirmResults(' . $messageUpdate  . ')">Update</a>';
+                    }
+                    $messageRemove = '\'Remove Meta from ' . $title . '?\'';
+                    echo ' - <a href="' . home_url() . '?meta=1&id=' . $post_id . '&action=remove" 
+                                onclick="return confirmResults(' . $messageRemove . ')">Remove</a>';
+                }
+
+                ?>
+            </td>
+            <td><?php echo $metaHTML; ?></td>
+        </tr>
+
+        <?php endforeach;
+    endif; ?>
+
+</table>

--- a/review/views/meta-dashboard.php
+++ b/review/views/meta-dashboard.php
@@ -4,31 +4,26 @@
             <th>
                 <h3>Meta Class</h3>
                 <h4>$meta = new Meta();</h4>
-                <p>Add `?meta=1` to url, to setup UI.</p>
-                <h4>$meta->setMeta();</h4>
-                <p>$meta->setMeta(array(
+                <p>$meta->meta = [
                 <br />&nbsp;&nbsp;&nbsp;&nbsp;'meta_key' => 'meta_value',
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'meta_key' => array('meta_value', 'new_value'),
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'meta_key' => ['meta_value', 'new_value'],
                 <br />&nbsp;&nbsp;&nbsp;&nbsp;'meta_key',
-                <br />));</p>
-                <h4>$meta->setQuery();</h4>
-                <p>$meta->setQuery(array(
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'posts' => array('343', 234, 12),
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'post_type' => array('post', 'cpt_post'),
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'parents' => array(45, 234, '23'),
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'taxonomy' => array( taxonomy => array('term_1', 'term_2')),
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'templates' => array('front-page.php'),
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'slug' => 'page-slug-name',
-                <br />&nbsp;&nbsp;&nbsp;&nbsp;'wp_args' => refer to $args for WP_Query.
-                <br />));</p>
-                <h4>$meta->init();</h4>
-                <p>Shows the results with defined fields &amp; query set.</p>
+                <br />];</p>
+                <p>$meta->query = [
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'posts'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; => ['343', 234, 12],
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'post_type' => ['post', 'cpt_post'],
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'parents'&nbsp;&nbsp;&nbsp;&nbsp; => [45, 234, '23'],
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'taxonomy' => ['taxonomy' => ['term_1', 'term_2']],
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'templates' => ['front-page.php'],
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'slug'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; => 'page-slug-name',
+                <br />&nbsp;&nbsp;&nbsp;&nbsp;'wp_args'&nbsp;&nbsp;&nbsp;&nbsp; => [], refer to $args for WP_Query.
+                <br />];</p>
+                <h4>$meta->build();</h4>
             </th>
-            <th>
 
+            <th>
                 <h5>Meta</h5>
                 <?php
-
                 $hasUpdates  = false;
                     
                 // Meta loop.
@@ -45,13 +40,11 @@
                 } else {
                     echo '<pre>Meta data not set.</pre>';
                 }
-
                 ?>
                 <hr />
 
                 <h5>Query</h5>
                 <?php
-
                 $hasSettings = false;
 
                 // Loop Queries.
@@ -72,13 +65,11 @@
                 if (!$hasSettings) {
                     echo '<pre>Query arguments not set, all post(s) queried.</pre>';
                 }
-
                 ?>
                 <hr />
 
                 <h5>Results</h5>
                 <?php
-
                 // Count, Results || Posts, if not 0 posts.
                 if (!empty($this->results)) {
                     echo '<pre>' . count($this->results) . ' Post(s) Effected</pre>';
@@ -108,7 +99,6 @@
                 if (!empty($_GET['id'])) {
                     echo '<a class="btn-back" href="' . home_url() . '?meta=1">Back</a>';
                 }
-
                 ?>
             </th>
         </tr>
@@ -116,12 +106,11 @@
 
     <tfoot>
         <tr>
-            <td colspan="2">Remove `init` method or `?meta=1` from url to exit this screen.</td>
+            <td colspan="2">Remove `build` method or `?meta=1` from url to exit this screen.</td>
         </tr>
     </tfoot>
 
     <?php
-
     // Results.
     if (!empty($this->results)) :
         foreach ($this->results as $post_id => $meta) :
@@ -133,9 +122,9 @@
                 <a href="<?php echo get_permalink($post_id); ?>">View Post</a> - 
                 <a href="<?php echo admin_url('post.php?post=' . $post_id . '&action=edit'); ?>">Edit Post</a>
             </td>
+
             <td>
             <?php
-
             if (!empty($meta)) {
                 foreach ($meta as $key => $value) {
                     echo '<pre class="' . $_GET['action'] . '"><strong>' . $key . '</strong> = ';
@@ -149,16 +138,16 @@
                     echo '</pre>';
                 }
             }
-
             ?>
             </td>
-            <tr>
+        </tr>
     <?php
         endforeach;
     elseif (!empty($this->posts) && empty($_GET['action'])) :
         foreach ($this->posts as $post_id => $title) :
             $metaHTML  = '';
             $hasUpdate = false;
+            $title     = strip_tags($title);
 
             // Meta values.
             if (!empty($this->meta)) {
@@ -175,23 +164,16 @@
                         $metaHTML .= '<strong>' . $key . '</strong> = ' . $storedValue;
 
                         // Remove link.
-                        $messageRemove = '\'Remove ' . strtoupper($key) . ' from ' . $title . '?\'';
                         $metaHTML .= ' <a class="link-remove" 
-                                          href="' . home_url() . '?meta=1&id=' . $post_id . '&metakey=' . $key . '&metavalue=' . $storedValue . '&action=remove" 
-                                          onclick="return confirmResults(' . $messageRemove . ')">Remove</a>';
+                                          href="' . home_url() . '?meta=1&id=' . $post_id . '&metakey=' . $key . '&action=remove" 
+                                          onclick="return confirmResults(\'Remove ' . strtoupper($key) . ' from ' . $title . '?\')">Remove</a>';
 
                         // Update link.
                         if (is_array($value)) {
                             $hasUpdate = true;
-                            $messageUpdate = '\'Update ' . strtoupper($key) . ' from ' . $title . '?\'';
                             $metaHTML .= ' <a class="link-update" 
-                                              href="' . home_url() . '?meta=1
-                                              &id=' . $post_id . '
-                                              &metakey=' . $key . '
-                                              &metavalue=' . $storedValue . '
-                                              &value=' . $value[1] . '
-                                              &action=update" 
-                                              onclick="return confirmResults(' . $messageUpdate . ')">Update</a>';
+                                              href="' . home_url() . '?meta=1&id=' . $post_id . '&metakey=' . $key . '&value=' . $value[1] . '&action=update" 
+                                              onclick="return confirmResults(\'Update ' . strtoupper($key) . ' from ' . $title . '?\')">Update</a>';
                         }
 
                         $metaHTML .= '</pre>';
@@ -202,37 +184,31 @@
                 $meta = get_post_meta($post_id);
 
                 foreach ($meta as $key => $value) {
-                    $messageRemove ='\'Remove ' . strtoupper($key) . ' from ' . $title . '?\'';
                     $metaHTML .= '<pre>';
                     $metaHTML .= '<strong>' . $key . '</strong> = ' . $value[0];
                     $metaHTML .= ' <a class="link-remove" 
-                                          href="' . home_url() . '?meta=1&id=' . $post_id . '&metakey=' . $key . '&metavalue=' . $value[0] . '&action=remove" 
-                                          onclick="return confirmResults(' . $messageRemove . ')">Remove</a>';
+                                          href="' . home_url() . '?meta=1&id=' . $post_id . '&metakey=' . $key . '&action=remove" 
+                                          onclick="return confirmResults(\'Remove ' . strtoupper($key) . ' from ' . $title . '?\')">Remove</a>';
                     $metaHTML .= '</pre>';
                 }
             }
-
         ?> 
 
         <tr>
             <td>
                 <strong><?php echo $title; ?></strong><br />
                 <strong>ID: </strong><?php echo $post_id; ?><br /><br />
-                <a href="<?php echo get_permalink($post_id); ?>">View</a> 
-                - <a href="<?php echo admin_url('post.php?post=' . $post_id . '&action=edit'); ?>">Edit</a>
+                <a href="<?php echo get_permalink($post_id); ?>">View</a> - 
+                <a href="<?php echo admin_url('post.php?post=' . $post_id . '&action=edit'); ?>">Edit</a>
                 <?php
-
                 if (!empty($this->meta)) {
                     if ($hasUpdate) {
-                        $messageUpdate = '\'Update Meta from ' . $title . '?\'';
                         echo ' - <a href="' . home_url() . '?meta=1&id=' . $post_id . '&action=update" 
-                                    onclick="return confirmResults(' . $messageUpdate  . ')">Update</a>';
+                                    onclick="return confirmResults(\'Update Meta from ' . $title . '?\')">Update</a>';
                     }
-                    $messageRemove = '\'Remove Meta from ' . $title . '?\'';
                     echo ' - <a href="' . home_url() . '?meta=1&id=' . $post_id . '&action=remove" 
-                                onclick="return confirmResults(' . $messageRemove . ')">Remove</a>';
+                                onclick="return confirmResults(\'Remove Meta from ' . $title . '?\')">Remove</a>';
                 }
-
                 ?>
             </td>
             <td><?php echo $metaHTML; ?></td>

--- a/src/Metabox.php
+++ b/src/Metabox.php
@@ -103,37 +103,38 @@ class Metabox
      */
     public function build()
     {
-        add_action(
-            'init',
-            function () {
+        add_action('init', function () {
+
             // Set Post ID.
-                $this->setPostID();
+            $this->setPostID();
+
 
             // Setup Settings.
-                $this->setupSettings();
+            $this->setupSettings();
+
 
             // Initiate if in adminstrator area.
-                if (!$this->validateSettings()) {
-                    return;
-                }
+            if (!$this->validateSettings()) {
+                return;
+            }
+
 
             // Check to see if assets already loaded, only load assets once.
-                if (!self::$assetsLoaded) {
-                    self::$assetsLoaded = true;
+            if (!self::$assetsLoaded) {
+                self::$assetsLoaded = true;
 
-                    $this->addCDNAssets();
-                    $this->assetsHeader();
-                    $this->assetsFooter();
-                    $this->removeWPFeatures();
-                }
+                $this->addCDNAssets();
+                $this->assetsHeader();
+                $this->assetsFooter();
+                $this->removeWPFeatures();
+            }
+
 
             // Setup Fields, Create Metabox, Save Metabox.
-                $this->setupFields();
-                $this->initMetabox();
-                $this->initSavePost();
-            },
-            15
-        );
+            $this->setupFields();
+            $this->initMetabox();
+            $this->initSavePost();
+        }, 15);
     }
 
 
@@ -163,10 +164,12 @@ class Metabox
             $this->settings['id'] = rand(1, 100000);
         }
 
+
         // Set Prefix.
         if (!empty($this->settings['prefix']) && substr($this->settings['prefix'], -1) != '_') {
             $this->settings['prefix'] .= '_';
         }
+
 
         // If Properties delcared as strings, convert to arrays.
         foreach ($this->settings as $name => &$setting) {
@@ -186,6 +189,7 @@ class Metabox
             }
         }
 
+
         // Defaults Settings + User Defined Settings.
         $this->settings = array_merge($this->settingsDefaults, $this->settings);
     }
@@ -203,10 +207,12 @@ class Metabox
             return;
         }
 
+
         // Setup fields.
         foreach ($this->fields as $name => $attributes) {
             // Remove array item, only to re-build it below.
             unset($this->fields[$name]);
+
 
             // If Instructions/Snippet
             if (is_int($name) && is_string($attributes)) {
@@ -214,8 +220,10 @@ class Metabox
                 continue;
             }
 
+
             // Set prefixed name.
             $name = $this->settings['prefix'] . $name;
+
 
             // Stored Value.
             $storedValue = get_post_meta($this->postID, $name, true);
@@ -229,15 +237,19 @@ class Metabox
                     $valueArray = is_object($valueArray) ? [$valueArray] : $valueArray;
                 }
             }
-        
+
+
             // Prefix & Merge Attributes with defaults.
             $this->fields[$name] = array_merge($this->fieldDefaults, $attributes);
+
 
             // Subfields.
             if (empty($attributes['subfields'])) {
                 continue;
             }
 
+
+            // Loop Subfields.
             foreach ($attributes['subfields'] as $subName => $subAttributes) {
                 // If Instructions/Snippet
                 if (is_int($subName) && is_string($subAttributes)) {
@@ -245,14 +257,17 @@ class Metabox
                     continue;
                 }
 
+
                 // Prefix & Merge Attributes with defaults.
                 $this->fields[$name]['subfields'][$subName] = array_merge($this->fieldDefaults, $subAttributes);
 
-                // Add Values to subfields.
+
+                // Check if values exists.
                 if (empty($valueArray)) {
                     continue;
                 }
 
+                // Add Values to subfields.
                 foreach ($valueArray as $valueName => $value) {
                     $this->fields[$name]['subfields'][$subName]['values'][] = $value->$subName;
                 }
@@ -267,32 +282,21 @@ class Metabox
      */
     private function addCDNAssets()
     {
-        add_action(
-            'admin_enqueue_scripts',
-            function () {
+        add_action('admin_enqueue_scripts', function () {
+
             // Remove Old ACF Versions of Select2
-                wp_deregister_script('select2');
-                wp_deregister_style('select2');
+            wp_deregister_script('select2');
+            wp_deregister_style('select2');
+
 
             // Add styles to administrator area.
-                wp_register_style(
-                    'select2-css',
-                    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css',
-                    false,
-                    '4.0.3'
-                );
-                wp_enqueue_style('select2-css');
+            wp_register_style('select2-css', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css', false, '4.0.3');
+            wp_enqueue_style('select2-css');
+
 
             // Add script to administrator area.
-                wp_enqueue_script(
-                    'select2-js',
-                    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js',
-                    ['jquery', 'jquery-ui-sortable'],
-                    null,
-                    false
-                );
-            }
-        );
+            wp_enqueue_script('select2-js', 'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js', ['jquery', 'jquery-ui-sortable'], null, false);
+        });
     }
 
 
@@ -302,12 +306,9 @@ class Metabox
      */
     private function assetsHeader()
     {
-        add_action(
-            'admin_head',
-            function () {
-                echo file_get_contents(dirname(__FILE__). '/assets/metabox-styles.css');
-            }
-        );
+        add_action('admin_head', function () {
+            echo file_get_contents(dirname(__FILE__). '/assets/metabox-styles.css');
+        });
     }
 
 
@@ -317,15 +318,9 @@ class Metabox
      */
     private function assetsFooter()
     {
-        add_action(
-            'admin_footer',
-            function () {
-                echo '<script>';
-                echo file_get_contents(dirname(__FILE__) . '/assets/metabox-scripts.js');
-                echo '</script>';
-            },
-            20
-        );
+        add_action('admin_footer', function () {
+            echo '<script>' . file_get_contents(dirname(__FILE__) . '/assets/metabox-scripts.js') . '</script>';
+        }, 20);
     }
 
 
@@ -339,18 +334,14 @@ class Metabox
      */
     private function removeWPFeatures()
     {
-        if (empty($this->settings['remove'])) {
-            return;
-        }
-
+        // Remove Features.
         foreach ($this->settings['remove'] as $feature) {
             remove_post_type_support(get_post_type($this->postID), $feature);
         }
 
+
         // Remove Spacing Issue
-        if (in_array('title', $this->settings['remove']) &&
-            in_array('editor', $this->settings['remove'])
-        ) {
+        if (in_array('title', $this->settings['remove']) && in_array('editor', $this->settings['remove'])) {
             echo '<style>#post-body-content { display:none; }</style>';
         }
     }
@@ -366,6 +357,7 @@ class Metabox
     private function initMetabox()
     {
         add_action('add_meta_boxes', function () {
+
             // Add Metabox.
             add_meta_box(
                 'custom-metabox-' . $this->settings['id'],
@@ -376,15 +368,13 @@ class Metabox
                 $this->settings['priority']
             );
 
+
             // Add dependency class to metabox container to initially hide.
             if (!empty($this->settings['dependency'])) {
-                add_filter(
-                    'postbox_classes_' . get_post_type($this->postID) . '_custom-metabox-' . $this->settings['id'],
-                    function ($classes) {
-                        $classes[] = 'data-dependency-key';
-                        return $classes;
-                    }
-                );
+                add_filter('postbox_classes_' . get_post_type($this->postID) . '_custom-metabox-' . $this->settings['id'], function ($classes) {
+                    $classes[] = 'data-dependency-key';
+                    return $classes;
+                });
             }
         });
     }
@@ -399,26 +389,28 @@ class Metabox
         // Add nonce for security and authentication.
         wp_nonce_field($this->nonceAction, $this->nonceName);
 
+
         // Condition Dependency.
         if (!empty($this->settings['dependency'])) {
             $condition  = ' data-dependency-key="' . $this->settings['dependency']['key'] . '"';
             $condition .= ' data-dependency-value=\'' . $this->settings['dependency']['value'] . '\'';
             $condition .= ' data-dependency-condition="' . $this->settings['dependency']['condition'] . '"';
 
-            echo '<span data-key="custom-metabox-' . $this->settings['id'] . '" 
-                        data-type="metabox" 
-                        ' . $condition . '></span>';
+            echo '<span data-key="custom-metabox-' . $this->settings['id'] . '" data-type="metabox" ' . $condition . '></span>';
         }
+
 
         // Show metabox instructions.
         if (!empty($this->settings['instructions'])) {
             echo '<div class="instructions">' . $this->settings['instructions'] . '</div>';
         }
 
+
         // Check if fields are empty.
         if (empty($this->fields)) {
             return;
         }
+
 
         $this->getFields();
     }
@@ -444,31 +436,32 @@ class Metabox
                     $condition .= ' data-dependency-condition="' . $attributes['dependency']['condition'] . '"';
                 }
 
+
                 // Field markup.
-                echo '<div class="input-group type-object" 
-                           data-key="' . $name . '" 
-                           data-type="object" 
-                           ' . $condition . '>';
-            
+                echo '<div class="input-group type-object" data-key="' . $name . '" data-type="object" ' . $condition . '>';
+
+
                 // Set label if exists.
                 if (!empty($attributes['label'])) {
                     echo '<span class="label">' . $attributes['label'] . '</span>';
                 }
+
 
                 // Set description if exists.
                 if (!empty($attributes['description'])) {
                     echo '<div class="description">' . $attributes['description'] . '</div>';
                 }
 
+
                 // Subfields.
-                echo '<div data-subfields-container="' . $name . '" 
-                           ' . ($attributes['repeater'] ? 'data-repeater="true"' : '') . '>';
+                echo '<div data-subfields-container="' . $name . '" ' . ($attributes['repeater'] ? 'data-repeater="true"' : '') . '>';
 
                 $count = 1;
 
                 if ($attributes['repeater'] && !empty(reset($attributes['subfields'])['values'])) {
                     $count = count(reset($attributes['subfields'])['values']);
                 }
+
 
                 for ($i = 0; $i < $count; $i++) {
                     echo '<div data-subfields-parent="' . $name . '">';
@@ -480,7 +473,7 @@ class Metabox
                         } else {
                             $subName = $name . '[' . $subName . ']';
                         }
-                        
+
                         // Update Value.
                         $subAttributes['value'] = '';
 
@@ -498,18 +491,20 @@ class Metabox
                     echo '</div>';
                 }
 
+
                 // End of Input Area.
                 echo '</div>';
 
+
                 // If repeater.
                 if ($attributes['repeater']) {
-                    echo '<div class="button-controls">
-                            <button data-subfields-add="' . $name . '" class="button-primary">Add</button>
-                          </div>';
+                    echo '<div class="button-controls"><button data-subfields-add="' . $name . '" class="button-primary">Add</button></div>';
                 }
+
 
                 // End of Field Group.
                 echo '</div>';
+
 
                 // Jump to next field.
                 continue;
@@ -531,11 +526,13 @@ class Metabox
         // Extract field attributes.
         extract($attributes);
 
+
         // HTML/Message Snippet.
         if (!empty($snippet)) {
             echo '<div class="snippet">' . $snippet . '</div>';
             return;
         }
+
 
         // Field exists.
         if (empty($type) || !file_exists(dirname(__FILE__) . '/fields/' . $type . '.php')) {
@@ -543,10 +540,12 @@ class Metabox
             return;
         }
 
+
         // Multiselect, append [] to name.
         if ($type == 'select-multiple') {
             $name .= '[]';
         }
+
 
         // Label html.
         $labelHTML = '';
@@ -555,26 +554,23 @@ class Metabox
             $labelHTML    = '<label for="' . $name . '">' . $label . $requiredHTML . '</label>';
         }
 
+
         // Description html.
         $descriptionHTML = !empty($description) ? '<div class="description">' . $description . '</div>' : '';
 
+
         // Conditional dependency.
         $condition = '';
-
         if (!empty($dependency)) {
             $condition  = ' data-dependency-key="' . $dependency['key'] . '"';
             $condition .= ' data-dependency-value=\'' . $dependency['value'] . '\'';
             $condition .= ' data-dependency-condition="' . $dependency['condition'] . '"';
         }
 
+
         // Field group.
-        echo '<div class="input-group type-' . $type . '" 
-                   data-key="' . $name . '" 
-                   data-type="' . $type . '"
-                   ' . $condition . '>';
-
+        echo '<div class="input-group type-' . $type . '" data-key="' . $name . '" data-type="' . $type . '" ' . $condition . '>';
         include dirname(__FILE__) . '/fields/' . $type . '.php';
-
         echo '</div>';
     }
 
@@ -586,10 +582,12 @@ class Metabox
     private function initSavePost()
     {
         add_action('save_post', function () {
+
             // Validation Check.
             if (!$this->validateSaveRequest()) {
                 return;
             }
+
 
             // Loop through Meta Fields.
             foreach ($this->fields as $name => $attributes) {
@@ -604,7 +602,7 @@ class Metabox
                 }
 
                 // Subfields.
-                if (!empty($attributes['subfields'])) {
+                if (!empty($attributes['subfields']) && is_array($_POST[$name])) {
                     $hasValue = false;
 
                     // If repeater check deeper array.
@@ -646,19 +644,19 @@ class Metabox
                     }
                 }
 
+
                 // Delete Post Meta Fields if Empty.
                 if (empty($_POST[$name]) && $attributes['type'] != 'radio') {
-                    delete_post_meta(
-                        $this->postID,
-                        $name
-                    );
+                    delete_post_meta($this->postID, $name);
                     continue;
                 }
+
 
                 // select2-multiple: Convert Value to Array.
                 if (!empty($attributes['type']) && $attributes['type'] == 'select2-multiple') {
                     $_POST[$name] = explode(',', $_POST[$name]);
                 }
+
 
                 // If is value is array
                 if (is_array($_POST[$name])) {
@@ -674,13 +672,10 @@ class Metabox
                         throw new \Exception('JSON encoding failed with error:' . json_last_error_msg());
                     }
                 }
-                
+
+
                 // Update Post Meta Fields.
-                update_post_meta(
-                    $this->postID,
-                    $name,
-                    $_POST[$name]
-                );
+                update_post_meta($this->postID, $name, $_POST[$name]);
             }
         });
     }
@@ -699,35 +694,42 @@ class Metabox
             return false;
         }
 
+
         // Add nonce for security and authentication
         if (!isset($_POST[$this->nonceName])) {
             return false;
         }
+
 
         // Check if nonce is set & nonce is valid.
         if (!wp_verify_nonce($_POST[$this->nonceName], $this->nonceAction)) {
             return false;
         }
 
+
         // Check if user has permissions to save data.
         if (!current_user_can('edit_post', $this->postID)) {
             return false;
         }
+
 
         // Check if not an autosave.
         if (wp_is_post_autosave($this->postID)) {
             return false;
         }
 
+
         // Check if not a revision.
         if (wp_is_post_revision($this->postID)) {
             return false;
         }
 
+
         // Check if fields are empty.
         if (empty($this->fields)) {
             return false;
         }
+
 
         return true;
     }
@@ -743,63 +745,72 @@ class Metabox
      */
     private function validateSettings()
     {
-        // Check if post is empty.
-        if (empty($this->postID)) {
+        // Check if should be on all.
+        if (empty($this->settings['post_type']) &&
+            empty($this->settings['post']) &&
+            empty($this->settings['parent']) &&
+            empty($this->settings['taxonomy']) &&
+            empty($this->settings['template'])
+        ) {
             return true;
         }
+
+
+        // Check if new page & post type is set.
+        if (empty($this->postID) &&
+            !empty($_GET['post_type']) &&
+            in_array($_GET['post_type'], $this->settings['post_type'])
+        ) {
+            return true;
+        }
+
 
         // Check if Post(s).
-        if (!empty($this->settings['post']) &&
-            in_array($this->postID, $this->settings['post'])
-        ) {
+        if (in_array($this->postID, $this->settings['post'])) {
             return true;
         }
+
 
         // Check if Post Type.
-        if (!empty($this->settings['post_type']) &&
-            in_array(get_post_type($this->postID), $this->settings['post_type'])
-        ) {
+        if (in_array(get_post_type($this->postID), $this->settings['post_type'])) {
             return true;
         }
+
 
         // Check if Parent.
-        if (!empty($this->settings['parent']) &&
-            in_array(wp_get_post_parent_id($this->postID), $this->settings['parent'])
-        ) {
+        if (in_array(wp_get_post_parent_id($this->postID), $this->settings['parent'])) {
             return true;
         }
 
+
+        // Check if Template.
+        if (in_array(get_page_template_slug($this->postID), $this->settings['template'])) {
+            return true;
+        }
+
+
         // Check if settings.taxonomy is set.
-        if (!empty($this->settings['taxonomy'])) {
-            // Loop taxonomies & match terms for post.
-            foreach ($this->settings['taxonomy'] as $taxonomyAllowed => $termsAllowed) {
-                // Get post terms based on taxonomy.
-                $postTerms = get_the_terms($this->postID, $taxonomyAllowed);
+        foreach ($this->settings['taxonomy'] as $taxonomyAllowed => $termsAllowed) {
+            // Get post terms based on taxonomy.
+            $postTerms = get_the_terms($this->postID, $taxonomyAllowed);
 
-                // Check for if post terms.
-                if (is_wp_error($postTerms) || empty($postTerms)) {
-                    continue;
-                }
+            // Check for if post terms.
+            if (is_wp_error($postTerms) || empty($postTerms)) {
+                continue;
+            }
 
-                // Loop through post terms in taxonomy.
-                foreach ($postTerms as $postTerm) {
-                    // Check terms compared to user inputted array of values.
-                    if (in_array($postTerm->slug, $termsAllowed) ||
-                        in_array($postTerm->term_id, $termsAllowed) ||
-                        in_array($postTerm->name, $termsAllowed)
-                    ) {
-                        return true;
-                    }
+            // Loop through post terms in taxonomy.
+            foreach ($postTerms as $postTerm) {
+                // Check terms compared to user inputted array of values.
+                if (in_array($postTerm->slug, $termsAllowed) ||
+                    in_array($postTerm->term_id, $termsAllowed) ||
+                    in_array($postTerm->name, $termsAllowed)
+                ) {
+                    return true;
                 }
             }
         }
 
-        // Check if Template.
-        if (!empty($this->settings['template']) &&
-            in_array(get_page_template_slug($this->postID), $this->settings['template'])
-        ) {
-            return true;
-        }
 
         return false;
     }
@@ -816,6 +827,7 @@ class Metabox
             return true;
         }
 
+
         // Data attribute of callback.
         $data = [
             'postID'     => $this->postID,
@@ -823,6 +835,7 @@ class Metabox
             'value'      => !empty($_POST[$name]) ? $_POST[$name] : '',
             'attributes' => $attributes
         ];
+
 
         // Callback Function, pass in value as data argument.
         return (call_user_func($attributes['callback'], $data) === false) ? false : true;


### PR DESCRIPTION
# Composer Setup
```
"require": {
    "wordpressmeta": "dev-master"
},
"repositories": [
    {
        "type": "vcs",
        "url": "https://github.com/HigherEducation/WordPressMeta"
    }
],
```

Install Meta Library project by using composer:
```
composer install
```

To Update:
```
composer update
```

If Composer is not isntall on your machine, run:
```
curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
```

Setup Autoloader in `functions.php`:
```
require_once ABSPATH . '../../vendor/autoload.php';
```


# Metabox
Used to build simple custom metabox.

## Initialize
```
use WordPressMeta\Metabox;

$metabox = new Metabox();
$metabox->settings = [
   ... Settings
];
$metabox->fields = [
    ... Fields
];
$metabox->build();
```

## Settings
```
[
    'title'        => '',
    'id'           => '',
    'instructions' => '',
    'prefix'       => '',
    'post_type'    => [] || '',
    'post'         => [] || '',
    'parent'       => [] || '',
    'template'     => [] || '',
    'taxonomy'     => [],
    'operator'     => '',
    'location'     => 'normal',
    'priority'     => 'high',
    'dependency'   => [],
    'remove'       => ['custom-fields']
]
```

##### title
(string) (Required) Title of the meta box.

##### id
(string) (Optional) Unique ID of metabox, if not entered will autogenerate a random number custom-metabox-`1-100000`.

##### instructions
(string) (Optional) Can contain html tags.

##### prefix
(string) (Optional) Adds to the field names below. So prefix = `something` will append `something_fieldname`. If you add the `something_` it will still be `something_fieldname`.

##### location
(string) (Optional) The context within the screen where the boxes should display. Available contexts vary from screen to screen. Post edit screen contexts include 'normal', 'side', and 'advanced'. Comments screen contexts include 'normal' and 'side'. Default `normal`.

##### priority
(string) (Optional) The priority within the context where the boxes should show ('high', 'low'). Default `high`.

##### post_type
(string|array) (Optional) The post type which to show the box. Accepts a single post type or an array of post types. Default `all post` types.

##### post
(string|array) (Optional) Metabox will only display on specific posts entered into array. e.g. `['242', '234', '12']` or `'12'`

##### parent
(string|array) (Optional) Metabox will only display on children posts of specific parent post(s) entered into array. e.g. `['242']` or `'242'`

##### taxonomy
(array) (Optional) Metabox will only display on terms that are specified in taxonomies. e.g. `['category' => 'rankings']` or `['category' => 'rankings', 'post_tag' => 'schools']` or `['category' => ['rankings', 'schools'], 'post_tag' => 'schools']`

##### template
(string|array) (Optional) Metabox will only display on specified template. e.g. `['front-page.php', 'contact-page.php']` or `'front-page.php'`

##### operator
(string) (Optional) How you'd like to query your location rules together, `post_type`, `post`, `parent`, `taxonomy`. Accepts `AND` or `OR`. Default is set to 'OR'.

##### dependency 
(array) (Optional) Metabox dependency based on metafield conditions. Conditionals include `>, <, >=, <=, ==, !=, between, outside`. For `>, <, >=, <=`, only accept numeric values. For `==, !=`, can accept single value or array of values to match. e.g. `value` or `[3, "343", 55, "Value"]`. For `between & outside` only accepts array of values. e.g. `[2, 6]`. 
```
'dependency' => [
    'key'       => 'metakey',
    'value'     => 'value', // Format: 'value' || '[value, value, ...]'
    'condition' => '>, <, >=, <=, ==, !=, between, outside',
]
```

##### remove
(string|array) (Optional) Remove support for a feature from a post type. `custom-fields` is set as default.
- 'title'
- 'editor' (content)
- 'author'
- 'thumbnail' (featured image) (current theme must also support Post Thumbnails)
- 'excerpt'
- 'trackbacks'
- 'custom-fields'
- 'comments' (also will see comment count balloon on edit screen)
- 'revisions' (will store revisions)
- 'page-attributes' (template and menu order) (hierarchical must be true)
- 'post-formats' removes post formats, 


## Fields
```
$metabox->fields = [
    ...
];
```

##### Checkbox
```
'metakey' => [
    'type'        => 'checkbox',
    'label'       => '', 
    'description' => '', 
    'dependency'  => [],
    'callback'    => '',
],
```
Checkboxes, values are always `0` & `1`. e.g. If checked `metakey` will have meta value of `1` otherwise it'll be `0`. 


##### Date
```
'metakey' => [
    'type'        => 'date', 
    'value'       => '', // Format: YYYY-MM-DD
    'label'       => '', 
    'description' => '', 
    'required'    => false,
    'readonly'    => false,
    'pattern'     => '',
    'dependency'  => [],
    'style'       => '',
    'callback'    => '',
],
```


##### Editor
```
'metakey' => [
    'type'        => 'editor', 
    'value'       => '',
    'label'       => '', 
    'description' => '', 
    'dependency'  => [],
    'callback'    => '',
],
```


##### Email
```
'metakey' => [
    'type'        => 'email', 
    'value'       => '',
    'label'       => '', 
    'placeholder' => '', 
    'description' => '', 
    'required'    => false,
    'readonly'    => false,
    'pattern'     => '',
    'maxlength'   => '',
    'dependency'  => [],
    'style'       => '',
    'callback'    => '',
],
```


##### Number
```
'metakey' => [
    'type'        => 'number', 
    'value'       => '',
    'label'       => '', 
    'placeholder' => '', 
    'description' => '', 
    'required'    => false,
    'readonly'    => false,
    'pattern'     => '',
    'min'         => '',
    'max'         => '',
    'maxlength'   => '',
    'dependency'  => [],
    'style'       => '',
    'callback'    => '',
],
```


##### Radio
```
'metakey' => [
    'type'        => 'radio', 
    'label'       => '', 
    'description' => '', 
    'dependency'  => [],
    'options'     => ['Category 1' => 'value', 'Category 1' => 'value', ...],
    'callback'    => '',
],
```


##### Select
```
'metakey' => [
    'type'        => 'select-multiple', 
    'label'       => '', 
    'description' => '', 
    'required'    => false, 
    'dependency'  => [],
    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
    'style'       => '',
    'callback'    => '',
],
```


##### Select Multiple
```
'metakey' => [
    'type'        => 'select-multiple', 
    'label'       => '', 
    'description' => '', 
    'required'    => false, 
    'dependency'  => [],
    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
    'style'       => '',
    'callback'    => '',
],
```


##### Select2
```
'metakey' => [
    'type'        => 'select2', 
    'label'       => '', 
    'description' => '', 
    'required'    => false, 
    'dependency'  => [],
    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
    'callback'    => '',
],
```


##### Select2 Multiple
```
'metakey' => [
    'type'        => 'select2-multiple', 
    'label'       => '', 
    'description' => '', 
    'required'    => false, 
    'dependency'  => [],
    'options'     => ['Label' => 'value', 'Label' => 'value', ...],
    'callback'    => '',
],
```


##### Tel
```
'metakey' => [
    'type'        => 'tel', 
    'value'       => '',
    'label'       => '', 
    'placeholder' => '', 
    'description' => '', 
    'required'    => false,
    'readonly'    => false,
    'pattern'     => '', 
    'maxlength'   => '',
    'dependency'  => [],
    'style'       => '',
    'callback'    => '',
],
```
For validation, use `pattern` attribute with `tel` input if browser doesn't support HTML5 `tel` validation.


##### Text
```
'metakey' => [
    'type'        => 'text', 
    'value'       => '',
    'label'       => '', 
    'placeholder' => '', 
    'description' => '', 
    'required'    => false,
    'readonly'    => false,
    'pattern'     => '',
    'maxlength'   => '',
    'dependency'  => [],
    'style'       => '',
    'callback'    => '',
],
```


##### Textarea
```
'metakey' => [
    'type'        => 'textarea', 
    'value'       => '',
    'label'       => '', 
    'description' => '', 
    'required'    => false,
    'readonly'    => false,
    'dependency'  => [],
    'style'       => '',
    'callback'    => '',
],
```


##### URL
```
'metakey' => [
    'type'        => 'url', 
    'value'       => '',
    'label'       => '', 
    'placeholder' => '', 
    'description' => '', 
    'required'    => false,
    'readonly'    => false,
    'pattern'     => '',
    'maxlength'   => '',
    'dependency'  => [],
    'style'       => '',
    'callback'    => '',
],
```

##### Snippet
```
'Lorem <strong>ipsum dolor</strong> sit amet, consectetur adipisicing elit. Architecto et repudiandae earum placeat ea, tempore error facilis, assumenda atque accusamus mollitia laborum fugit accusantium. Eligendi <a href="#">unde ratione</a> deleniti corrupti, quae.<hr />',
```
Can be inserted between metakeys to create titles, breaks, messages or additional instructions. 


##### Object
```
'metakey' => [
    'label'       => '',
    'description' => '',
    'dependency'  => [],
    'callback'    => '',
    'repeater'    => true|false
    'subfields'   => [
        'subkey' => [
            'type'   => 'text', 
            'value'  => '',
            'label'  => '',
            ...
        ],
        'subkey' => [
            'type'   => 'text', 
            'value'  => '',
            'label'  => '',
            ...
        ],
    ],
],
```
Builds a json object into the `metakey`, this can be a repeater with an array of objects stored if `repeater` set to true. Note: Editor field currently doesn't work with repeater field. Also subkeys do not except `dependency` or `callback` attributes.

### Field Properties Information

##### type
(string) (Required)

##### value 
(string) (Optional)

##### label 
(string) (Required)

##### placeholder 
(string) (Optional)

##### description 
(string) (Optional) Can contain html tags.

##### options 
(array) (Optional) e.g. `'options'  => ['Category 1' => 'value', 'Category 1' => 'value', ...]`

##### pattern 
(string) (Optional) The pattern attribute specifies a regular expression that the <input> element's value is checked against. Note: The pattern attribute works with the following input types: text, date, search, url, number, tel, and email. e.g. `[A-Za-z]{3}`

##### required 
(bool) (Optional)

##### readonly 
(bool) (Optional) Note: The readonly attribute works with the following input types: text, date, search, url, number, tel, and email.

##### maxlength
(number) (Optional) Note: The maxlength attribute works with the following input types: text, date, search, url, number, tel, and email.

##### min 
(number) (Optional) Note: The min attribute works with the following input types: number.

##### max 
(number) (Optional) Note: The max attribute works with the following input types: number.

##### dependency 
(array) (Optional) Field dependency based on other metafield conditions. Conditionals include `>, <, >=, <=, ==, !=, between, outside`. For `>, <, >=, <=`, only accept numeric values. For `==, !=`, can accept single value or array of values to match. e.g. `value` or `[3, "343", 55, "Value"]`. For `between & outside` only accepts array of values. e.g. `[2, 6]`. 

##### style 
(string) (Optional) Give the field a little more style love. Work with all fields except, select2s, checkbox, and radio field types. 

##### subfields 
(array) (Optional) Object children fields. This gets saved as an array. NOTE: `Dependency & Callbacks` attributes don't work with subfield attributes.

##### repeater 
(bool) (Optional) Whether or not object children subfields are repeated. This creates an array of objects. NOTE: `Editor` fields currently do not work in repeaters.

```
'dependency' => [
    'key'       => 'metakey',
    'value'     => 'value', // Format: 'value' || '[value, value, ...]'
    'condition' => '>, <, >=, <=, ==, !=, between, outside',
],
```


## Example Usage:
```
$widgetXYZ = new Metabox();
$widgetXYZ->settings = [
   'title'        => 'Title',
   'instructions' => '',
   'post_type'    => ['post', 'pages'],
   'location'     => 'side',
   'priority'     => 'high',
];
$widgetXYZ->fields = [
    'title' => [
        'value'       => 'Default Title Name',
        'type'        => 'text',
        'description' => '',
        'label'       => 'Title',
        'placeholder' => 'Title',
    ],
    'cta' => [
        'type'  => 'text',
        'label' => 'Title',
        'placeholder' => 'tittle',
        'pattern' => '[A-Za-z]{3}',
        'required' => true,
        'dependency' => [
            'key'       => 'title',
            'value'     => 'value',
            'condition' => '==',
        ]
    ],
    'degree_level_id' => [
        'type'  => 'select',
        'label' => 'Degree Level',
        'options'  => $arrayMap,
    ],
    'category_id' => [
        'type'  => 'select',
        'label' => 'Category',
        'options'  => ['Category 1' => 'value', 'Category 1' => 'value', ...],  
    ],
    'subject_id' => [
        'type'  => 'text',
        'label' => 'Degree Level',
        'options'  => ['Category 1' => 'value', 'Category 1' => 'value', ...],   
        'dependency' => [
            'key'       => 'category_id',
            'value'     => '[1, 6]',
            'condition' => '==',
        ]
    ],
];
$widgetXYZ->build();
```

# Meta Class
Used to retrieve meta fields with defined search query/fields. **Requirements to Use:** Logged into Wordpress as an Administrator and add `?meta=1` to the domain url, this brings up the Dashboard once you iniialize class below. 

### Initialize
```
use WordPressMeta\Meta;

$meta = new Meta;
$meta->meta = [
    ...Meta
];
$meta->query = [
    ...Query
];
$meta->build();
```
## Meta
```
[
    'metakey',
    'metakey' => '3',
    'metakey' => ['searchValue', 'replaceableValue'],
    'metakey' => ['2', '5'],
    'metakey' => ['1', '5'],
    'metakey'
)
```
#### Single Key: `'metakey'`
Pulls in posts with attached `metakey`, no matter the value. Basically equals this `metakey => *`. You may also do this. `'metakey' => '*'`

#### Key with Value: `'metakey' => 'value'` 
Pulls in posts where `metakey` equals `value`. You may also look for metakeys that exists but have no value. `'metakey' => ''`

#### Key with Array Value: `'metakey' => ['searchValue', 'replaceableValue']` 
Pulls in posts like above using the `searchValue`. This allows you to replace `metakey` values from the dashboard.


## Query
```
[
    'post'      => [],
    'post_type' => [],
    'parent'    => [],
    'taxonomy'  => ['taxonomy' => ['term', 'term']],
    'template'  => [],
    'slug'      => '',
    'wp_args'   => Refer to: https://codex.wordpress.org/Class_Reference/WP_Query,
)
```
##### post
(string|array) (Optional) Specific posts entered into array. e.g. `['242', '234', '12']`

##### post_type
(string|array) (Optional) Accepts a single post type or an array of post types. Default is all post types.

##### parent
(string|array) (Optional) Only children posts of specific parent post(s) entered into array. e.g. `['242')`

##### taxonomy
(array) (Optional) Only terms that are specified in taxonomies. e.g. `['category' => 'rankings']` or `['category' => 'rankings', 'post_tag' => 'schools']` or `['category' => ['rankings', 'schools'], 'post_tag' => 'schools']`

##### template
(string|array) (Optional) Only terms that are specified in template. e.g. `['front-page.php', 'contact-page.php']`

##### slug
(string) (Optional) Only page specified by slug. e.g. `'page-slug-name'`

##### wp_args
(array) (Optional) Refer to $args for WP_Query: https://codex.wordpress.org/Class_Reference/WP_Query.


#### Example Usage
```
$meta = new Meta;
$meta->meta = [
    'degree_level_id' => 2,
    'editorial_only_page' => [0, 2]
];
$meta->query = [
    'post'      => ['5474', '6505', '6504', '6503', '234234322'],
    'post_type' => ['post'],
    'parent'    => ['172'],
    'taxonomy'  => ['category' => ['college-rankings')],
    'template'  => ['page-banner.php'],
    'slug'      => 'page-slug-name',
    'wp_args'   => ['category__in' => [5, 6]],
];
$meta->build();
```