### PR TITLE
Hotfix - Saving issue with repeaters.

### DIFF
--- a/src/Metabox.php
+++ b/src/Metabox.php
@@ -604,7 +604,7 @@ class Metabox
                 }
 
                 // Subfields.
-                if (!empty($attributes['subfields'])) {
+                if (!empty($attributes['subfields']) && is_array($_POST[$name])) {
                     $hasValue = false;
 
                     // If repeater check deeper array.


### PR DESCRIPTION
Issue:
When saving a new post or editing the post content editor, repeater fields would disappear. 